### PR TITLE
Systemd readout units

### DIFF
--- a/systemd/system/README.md
+++ b/systemd/system/README.md
@@ -1,0 +1,4 @@
+# Systemd templates for FLP prototype
+
+To be deployed through Ansible, which outputs proper Systemd units:
+`ansible-playbook -i inventory/flpproto-control-testing -s site.yml -e "flpprototype_systemd=~/Control/systemd/system"`

--- a/systemd/system/flpprototype-readout.service.j2
+++ b/systemd/system/flpprototype-readout.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=O2 FlpPrototype readout process
+After=network.target
+AssertPathExistsGlob={{ flpprototype_readout_confdir }}/{{ flpprototype_readout_default_config }}
+
+[Service]
+ExecStart=/opt/o2-modules/bin/readout.exe file:{{ flpprototype_readout_confdir }}/{{ flpprototype_readout_default_config }}
+Restart=no

--- a/systemd/system/flpprototype-readout@.service.j2
+++ b/systemd/system/flpprototype-readout@.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=O2 FlpPrototype readout process
+After=network.target
+AssertPathExistsGlob={{ flpprototype_readout_confdir }}/%I.cfg
+
+[Service]
+ExecStart=/opt/o2-modules/bin/readout.exe file:{{ flpprototype_readout_confdir }}/%I.cfg
+Restart=no


### PR DESCRIPTION
Jinja2 templates for Systemd units (default and parametrized) for FLP prototype readout.
To be used with Ansible.