### PR TITLE
Fix missing link to boost program_options

### DIFF
--- a/occ/CMakeLists.txt
+++ b/occ/CMakeLists.txt
@@ -306,7 +306,8 @@ target_include_directories(${OCCLIBRARY}
 target_link_libraries(${OCCLIBRARY}
     PUBLIC
     gRPC::grpc++
-    protobuf::libprotobuf)
+    protobuf::libprotobuf
+    Boost::program_options)
 
 generate_export_header(${OCCLIBRARY})
 


### PR DESCRIPTION
On my Mac, but not on the test machine, I get an error when building (see at the bottom). 

I think that there is actually an error. Boost::program_options is not header only and thus it requires to be linked against the library. What puzzles me is how it can work in most cases. Maybe I am missing something ? 

```
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0: [ 42%] Linking CXX shared library lib/libOcc.dylib
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0: Undefined symbols for architecture x86_64:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::options_description::add_options()", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       OccInstance::ProgramOptions() in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::options_description::m_default_line_length", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       OccInstance::ProgramOptions() in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::options_description::options_description(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned int, unsigned int)", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       OccInstance::ProgramOptions() in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::options_description_easy_init::operator()(char const*, boost::program_options::value_semantic const*, char const*)", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       OccInstance::ProgramOptions() in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::arg", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       boost::program_options::typed_value<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, char>::name() const in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::validate(boost::any&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, int)", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       boost::program_options::typed_value<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, char>::xparse(boost::any&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) const in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::abstract_variables_map::operator[](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       OccInstance::portFromVariablesMap(boost::program_options::variables_map const&) in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "boost::program_options::value_semantic_codecvt_helper<char>::parse(boost::any&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, bool) const", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       vtable for boost::program_options::typed_value<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, char> in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:   "typeinfo for boost::program_options::value_semantic_codecvt_helper<char>", referenced from:
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0:       typeinfo for boost::program_options::typed_value<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, char> in OccInstance.cxx.o
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0: ld: symbol(s) not found for architecture x86_64
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0: clang: error: linker command failed with exit code 1 (use -v to see invocation)
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0: make[2]: *** [lib/libOcc.0.8.2.dylib] Error 1
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0: make[1]: *** [CMakeFiles/Occ.dir/all] Error 2
DEBUG:Control-OCCPlugin:Control-OCCPlugin:0: make: *** [all] Error 2
```