### PR TITLE
WIP [OCTRL-209] Add no-version to configuration import

### DIFF
--- a/coconut/cmd/configuration_import.go
+++ b/coconut/cmd/configuration_import.go
@@ -37,8 +37,8 @@ coconut conf import <component>/<entry> <file_path>
 coconut conf import <component> <entry> <file_path> --new-component
 coconut conf import <component>/<entry> <file_path> --format=json
 coconut conf import <component> <entry> <file_path>.json
-coconut conf import <component> <entry> <file_path> -no-versioning 
-coconut conf import <component> <entry> <file_path> -no-versioning --new-component
+coconut conf import <component> <entry> <file_path> --no-versioning 
+coconut conf import <component> <entry> <file_path> --no-versioning --new-component
 `,
 	Short: "Import a configuration file for the specified component and entry",
 	Long: `The configuration import command generates a timestamp and saves
@@ -53,5 +53,5 @@ func init() {
 	configurationCmd.AddCommand(configurationImportCmd)
 	configurationImportCmd.Flags().BoolP("new-component", "n",  false, "create a new configuration component while importing entry")
 	configurationImportCmd.Flags().StringP("format", "f",  "", "force a specific configuration file type, overriding any file extension")
-	configurationImportCmd.Flags().Bool("no-versioning",  false, "create a new configuration component without timestamp being generated as a version")
+	configurationImportCmd.Flags().Bool("no-versioning",  false, "create an unversioned configuration entry (no timestamps are stored)")
 }

--- a/coconut/cmd/configuration_import.go
+++ b/coconut/cmd/configuration_import.go
@@ -1,7 +1,7 @@
 /*
  * === This file is part of ALICE O² ===
  *
- * Copyright 2019 CERN and copyright holders of ALICE O².
+ * Copyright 2020 CERN and copyright holders of ALICE O².
  * Author: George Raduta <george.raduta@cern.ch>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -37,6 +37,8 @@ coconut conf import <component>/<entry> <file_path>
 coconut conf import <component> <entry> <file_path> --new-component
 coconut conf import <component>/<entry> <file_path> --format=json
 coconut conf import <component> <entry> <file_path>.json
+coconut conf import <component> <entry> <file_path> -no-versioning 
+coconut conf import <component> <entry> <file_path> -no-versioning --new-component
 `,
 	Short: "Import a configuration file for the specified component and entry",
 	Long: `The configuration import command generates a timestamp and saves
@@ -51,5 +53,5 @@ func init() {
 	configurationCmd.AddCommand(configurationImportCmd)
 	configurationImportCmd.Flags().BoolP("new-component", "n",  false, "create a new configuration component while importing entry")
 	configurationImportCmd.Flags().StringP("format", "f",  "", "force a specific configuration file type, overriding any file extension")
-
+	configurationImportCmd.Flags().Bool("no-versioning",  false, "create a new configuration component without timestamp being generated as a version")
 }

--- a/hacking/settings-mac.yaml
+++ b/hacking/settings-mac.yaml
@@ -1,8 +1,9 @@
 --- 
 controlport: 47102
 executor: /opt/o2control-executor
-mesosurl: "http://aidrefsrv21.cern.ch:5050/api/v1/scheduler"
+mesosurl: "http://localhost:5050/api/v1/scheduler"
+# mesosurl: "http://aidrefsrv21.cern.ch:5050/api/v1/scheduler"
 verbose: true
 veryverbose: true
 globalconfigurationuri: "file://hacking/config.yaml"
-repositoriesPath: "/Users/graduta/aliecs.d"
+coreWorkingDir: "/Users/graduta/aliecs.d"


### PR DESCRIPTION
Add 'no-versioning' option to `coconut configuration import` command.

Cases to treat:
* Using `no-versioning`:
  * Entry specified already exists and contains timestamps => Return error and inform users
  * 
* With versioning:
  * Entry specified already exists and contains no-versioning items => Return error and inform users`