### PR TITLE
WIP: [OCTRL-295] Fill configuration ptree from local file

### DIFF
--- a/occ/occlib/OccServer.cxx
+++ b/occ/occlib/OccServer.cxx
@@ -247,7 +247,11 @@ t_State OccServer::processStateTransition(const std::string& event, const boost:
     // STANDBY
     if (currentState==t_State::standby) {
         if (evt=="configure") {
-            err = m_rco->executeConfigure(properties);
+            if (!m_rco->getConfig().empty()) {
+              err = m_rco->executeConfigure(m_rco->getConfig());
+            } else {
+              err = m_rco->executeConfigure(properties);
+            }
             if (!err) {
                 newState = t_State::configured;
             } else {

--- a/occ/occlib/RuntimeControlledObject.cxx
+++ b/occ/occlib/RuntimeControlledObject.cxx
@@ -25,9 +25,8 @@
 
 #include "RuntimeControlledObject.h"
 
-#include "RuntimeControlledObjectPrivate.h"
-
 #include <boost/property_tree/ptree.hpp>
+#include "RuntimeControlledObjectPrivate.h"
 
 #include <thread>
 
@@ -57,6 +56,16 @@ t_State RuntimeControlledObject::getState() const
 const std::string RuntimeControlledObject::getName() const
 {
     return dPtr->mName;
+}
+
+void RuntimeControlledObject::setConfig(const boost::property_tree::ptree& properties)
+{
+  dPtr->setConfig(properties);
+}
+
+boost::property_tree::ptree RuntimeControlledObject::getConfig()
+{
+  return dPtr->getConfig();
 }
 
 int RuntimeControlledObject::executeConfigure(const boost::property_tree::ptree& properties)

--- a/occ/occlib/RuntimeControlledObject.h
+++ b/occ/occlib/RuntimeControlledObject.h
@@ -77,6 +77,8 @@ public:
      */
     t_State getState() const;
 
+    void setConfig(const boost::property_tree::ptree& properties);
+    boost::property_tree::ptree getConfig();
     /// Transition from standby to configured.
     /// 
     /// @param properties a boost::property_tree pushed by the control agent, containing

--- a/occ/occlib/RuntimeControlledObjectPrivate.h
+++ b/occ/occlib/RuntimeControlledObjectPrivate.h
@@ -35,6 +35,15 @@ class RuntimeControlledObjectPrivate {
     friend class RuntimeControlledObject;
     friend class OccServer;
 private:
+    boost::property_tree::ptree mProps;
+    void setConfig(const boost::property_tree::ptree& properties)
+    {
+      mProps = properties;
+    }
+    boost::property_tree::ptree getConfig()
+    {
+      return mProps;
+    }
     t_State mCurrentState;
     std::string mName;
     RunNumber mCurrentRunNumber;

--- a/occ/occlib/examples/dummy-process/CMakeLists.txt
+++ b/occ/occlib/examples/dummy-process/CMakeLists.txt
@@ -20,8 +20,9 @@
 # immunities granted to it by virtue of its status as an
 # Intergovernmental Organization or submit itself to any jurisdiction.
 
-set(DUMMYPROCESS occexample-dummy-process)
+find_package(Configuration REQUIRED)
 
+set(DUMMYPROCESS occexample-dummy-process)
 
 
 set(DUMMYPROCESS_SOURCES
@@ -33,6 +34,7 @@ add_executable(${DUMMYPROCESS}
 
 target_link_libraries(${DUMMYPROCESS} PUBLIC
     ${OCCLIBRARY}
+    AliceO2::Configuration
     Boost::program_options)
 
 target_include_directories(${DUMMYPROCESS} PUBLIC

--- a/occ/occlib/examples/dummy-process/main.cxx
+++ b/occ/occlib/examples/dummy-process/main.cxx
@@ -27,8 +27,10 @@
 #include <OccInstance.h>
 
 #include <boost/program_options.hpp>
+#include <Configuration/ConfigurationFactory.h>
 
 namespace po = boost::program_options;
+using o2::configuration::ConfigurationFactory;
 
 int main(int argc, char* argv[]) {
     po::options_description desc("Program options");
@@ -37,14 +39,21 @@ int main(int argc, char* argv[]) {
     // finally, the ones from OccInstance must be appended in order to handle --control-port:
     desc.add(OccInstance::ProgramOptions());
 
+    desc.add_options()("config", po::value<std::string>(), "Config file URL");
+
     // Boost::program_options boilerplate...
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
 
     // Instantiate your state machine which inherits from RuntimeControlledObject:
-    ControlledStateMachine csm;
+    ControlledStateMachine csm{};
     // Nothing is happening yet, the state machine starts in t_State::undefined.
+
+    // Habdle loading file from config
+    if (vm.count("config")) {
+      csm.setConfig(ConfigurationFactory::getConfiguration(vm["config"].as<std::string>())->getRecursive(""));
+    }
 
     // Instantiate the O² Control and Configuration interface:
     OccInstance occ(&csm, vm);


### PR DESCRIPTION
TODO:
- [ ] Add missing comments, review existing ones
- [ ] `m_rco->executeConfigure(m_rco->getConfig());` looks a bit overkill, make sure there's no more elegant way