### PR TITLE
[OCTRL-388] Add a state "done" for completed auto env

### DIFF
--- a/core/environment/manager.go
+++ b/core/environment/manager.go
@@ -250,7 +250,7 @@ func (envs *Manager) TeardownEnvironment(environmentId uid.ID, force bool) error
 			len(taskReleaseErrors), environmentId)
 		return err
 	}
-	env.sendEnvironmentEvent(&event.EnvironmentEvent{EnvironmentID: env.Id().String(), Message: "teardown complete"})
+	env.sendEnvironmentEvent(&event.EnvironmentEvent{EnvironmentID: env.Id().String(), Message: "teardown complete", State: "DONE"})
 
 	envs.mu.Unlock()
 	// we trigger all cleanup hooks


### PR DESCRIPTION
This is proving to be a must. Due to the fact that `onEnd` is being called no matter what (even if stream failed or succeeded), currently there is no way for me to tell when the `NewAutoEnv` has been successful unless I specifically look for the message `teardown complete` which I believe is not recommended.

I would recommend to have for this release an ending state such as the ones proposed by Teo. 
I used the `DONE` state as per the `state.go` enum file which contains the possible states of a task.

Please feel free to change it to something else if environments do not use the same convention
