### PR TITLE
[core] Transition configure should return immediately after failure in deployment

### DIFF
--- a/core/environment/transition_configure.go
+++ b/core/environment/transition_configure.go
@@ -195,6 +195,12 @@ func (t ConfigureTransition) do(env *Environment) (err error) {
 			// `environment list` to be done almost immediatelly after mesos informs with TASK_FAILED.
 			case wfState := <-notifyState:
 				if wfState == task.ERROR {
+					workflow.LeafWalk(wf, func(role workflow.Role) {
+						if st := role.GetState();  st == task.ERROR {
+							log.WithField("state", st).
+				    			Error(fmt.Sprintf("%s role failed", role.GetName()))
+						}
+					})
 					log.WithField("state", wfState.String()).
 				    	Debug("workflow state change")
 					err = errors.New("workflow deployment failed")

--- a/core/environment/transition_configure.go
+++ b/core/environment/transition_configure.go
@@ -198,12 +198,14 @@ func (t ConfigureTransition) do(env *Environment) (err error) {
 					workflow.LeafWalk(wf, func(role workflow.Role) {
 						if st := role.GetState();  st == task.ERROR {
 							log.WithField("state", st).
-				    			Error(fmt.Sprintf("%s role failed", role.GetName()))
+								WithField("role", role.GetPath()).
+								WithField("environment", role.GetEnvironmentId().String()).
+								Error("environment reached invalid state")
 						}
 					})
 					log.WithField("state", wfState.String()).
 				    	Debug("workflow state change")
-					err = errors.New("workflow deployment failed")
+					err = errors.New("workflow deployment failed, aborting and cleaning up")
 					break WORKFLOW_ACTIVE_LOOP
 				}
 			}

--- a/core/workflow/iteratorrole.go
+++ b/core/workflow/iteratorrole.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 
 	"github.com/AliceO2Group/Control/common/gera"
+	"github.com/AliceO2Group/Control/common/utils/uid"
 	"github.com/AliceO2Group/Control/core/repos"
 
 	"github.com/AliceO2Group/Control/core/task"
@@ -326,4 +327,14 @@ func (i *iteratorRole) GetCurrentRunNumber() uint32 {
 		return 0
 	}
 	return i.GetParent().GetCurrentRunNumber()
+}
+
+func (i *iteratorRole) GetEnvironmentId() uid.ID {
+	if i == nil {
+		return uid.NilID()
+	}
+	if i.GetParent() == nil {
+		return uid.NilID()
+	}
+	return i.GetParent().GetEnvironmentId()
 }

--- a/core/workflow/role.go
+++ b/core/workflow/role.go
@@ -63,6 +63,7 @@ type Role interface {
 	IsEnabled() bool
 	GetCurrentRunNumber() uint32
 	ConsolidatedVarStack() (varStack map[string]string, err error)
+	GetEnvironmentId() uid.ID
 }
 
 type PublicUpdatable interface {


### PR DESCRIPTION
Tested using standalone deployment.
The procedure was:

1) `coconut environment create -w readout-dataflow -e '{"hosts":["test-flp3"],"dd_enabled": "true","qcdd_enabled": "true","modulepath":"nil"}'` forcing wrong variable so that the deployment will fail
2) coconut will respond with `FATAL create:      command finished with error error=rpc error: code = DeadlineExceeded desc = context deadline exceeded`
3) After a few seconds `mesos` will inform the core about the tasks with state `TASK_FAILED` and `REASON_COMMAND_EXECUTOR_FAILED`
4) `transition_configure` will exit immediately with `workflow deployment failed`
5) clean up of the remaining tasks will start immediately

Resolves OCTRL-373