### PR TITLE
Improvements to executor controllabletask.Kill

### DIFF
--- a/executor/executable/pid_util.go
+++ b/executor/executable/pid_util.go
@@ -31,8 +31,12 @@ import (
 
 // pidExists will check if a pid process is running
 func pidExists(pid int) (bool) {
-	if pid <= 0 {
+	if pid == 0 {
 		return false
+	} else if pid < 0 {
+		// A negative PID should still be acceptable, means it's a PGID
+		// so we make it positive to make it work with os.FindProcess
+		pid *= -1
 	}
 	proc, err := os.FindProcess(pid)
 	if err != nil {

--- a/executor/executorcmd/client.go
+++ b/executor/executorcmd/client.go
@@ -50,8 +50,7 @@ const (
 	ProtobufTransport = ControlTransport(0)
 	JsonTransport = ControlTransport(1)
 )
-const GRPC_DIAL_TIMEOUT = 75 * time.Second
-// Very long timeout to work around very slow aliswmod issue
+const GRPC_DIAL_TIMEOUT = 30 * time.Second
 
 func NewClient(
 	controlPort uint64,


### PR DESCRIPTION
I stumbled onto this almost by accident while debugging the Kill code path for other reasons, and I suspect it really *might* fix OCTRL-401 (but I'm not sure at all, testing needed).

If my assumption is correct, I suspect the problem was that the PID used by the Kill code depends on `GetState`, and prior to this fix a failed `GetState` could result in a negative PID, which was always treated as "process not running" by the `pidExists` check. Even if this doesn't fix OCTRL-401, I think it addresses a real problem.

@miltalex I know this is assigned to you and `IN PROGRESS`, I decided to just push my fix attempt here anyway because I couldn't find a branch on your end.