### PR TITLE
[core] Fix teardown and failed deployment issues

### DIFF
--- a/coconut/control/control.go
+++ b/coconut/control/control.go
@@ -240,7 +240,7 @@ func CreateEnvironment(cxt context.Context, rpc *coconut.RpcClient, cmd *cobra.C
 					fmt.Printf("\nEnvironment with id %s failed with error: %s\n", evt.EnvironmentId, evt.Error)
 					return nil
 				}
-				tmpl, err := template.New("envEvents").Parse("Enviroment {{.EnvironmentId}} {{if .Message}}{{.Message}}{{end}}{{if .State}}changed state to {{.State}}{{end}}{{if .CurrentRunNumber}} with run number {{.CurrentRunNumber}}{{end}}\n")
+				tmpl, err := template.New("envEvents").Parse("Enviroment {{.EnvironmentId}} {{if .Message}}{{.Message}} {{end}}{{if .State}}changed state to {{.State}}{{end}}{{if .CurrentRunNumber}} with run number {{.CurrentRunNumber}}{{end}}\n")
 				if err != nil {
 					return err
 				}

--- a/core/environment/manager.go
+++ b/core/environment/manager.go
@@ -202,8 +202,11 @@ func (envs *Manager) TeardownEnvironment(environmentId uid.ID, force bool) error
 	// we kill all tasks that aren't cleanup hooks
 	taskmanMessage := task.NewEnvironmentMessage(taskop.ReleaseTasks, environmentId, tasksToRelease, nil)
 	// close state channel
-	close(envs.pendingStateChangeCh[environmentId])
+	if ch := envs.pendingStateChangeCh[environmentId]; ch != nil {
+		close(envs.pendingStateChangeCh[environmentId])
+	}
 	delete(envs.pendingStateChangeCh, environmentId)
+	
 
 
 	// We set all callRoles to INACTIVE right now, because there's no task activation for them.

--- a/core/environment/manager.go
+++ b/core/environment/manager.go
@@ -356,7 +356,7 @@ func (envs *Manager) handleDeviceEvent(evt event.DeviceEvent) {
 			t := envs.taskman.GetTask(taskId.Value)
 			isHook := false
 			if t != nil {
-				t.SendEvent(&event.TaskEvent{Name: t.GetName(), TaskID: taskId.String(), Status: btt.FinalMesosState.String(), Hostname: t.GetHostname() , ClassName: t.GetClassName()})
+				t.SendEvent(&event.TaskEvent{Name: t.GetName(), TaskID: taskId.Value, Status: btt.FinalMesosState.String(), Hostname: t.GetHostname() , ClassName: t.GetClassName()})
 				if parentRole, ok := t.GetParentRole().(workflow.Role); ok {
 					parentRole.SetRuntimeVars(map[string]string{
 						"taskResult.exitCode": strconv.Itoa(btt.ExitCode),


### PR DESCRIPTION
The first one was noticed after executing `coconut environment create -w readout-dataflow -e '{"hosts":["test-flp3"],"modulepath":"/no/path/here/"}'`, the environment deployment was failing tasks were killed but `mesos` and `roster` were reporting leftover tasks.

The second is a fix for when a failing deployment is happening if `core` receives a `SIGINT` signal during the `TeardownEnvironment` operation, it will fail with `panic close nil channel`.