### PR TITLE
[core] Fix empty roster issue

### DIFF
--- a/core/task/manager.go
+++ b/core/task/manager.go
@@ -728,7 +728,7 @@ func (m *Manager) doKillTasks(tasks Tasks) (killed Tasks, running Tasks, err err
 	// if we couldn't kill a task add it back to the roster 
 	m.roster.updateTasks(m.roster.filtered(func(task *Task) bool {
 		return !tasks.Contains(func(t *Task) bool {
-			return task.status == ACTIVE 
+			return t.taskId == task.taskId
 		})
 	}))
 


### PR DESCRIPTION
When I patched the `v0.20.5`, I was removing every `ACTIVE` task on the roster instead of the ones that we supposed to kill.