### PR TITLE
[core] Report a channel mismatch error on bad channel configuration

### DIFF
--- a/core/environment/manager.go
+++ b/core/environment/manager.go
@@ -158,7 +158,10 @@ func (envs *Manager) CreateEnvironment(workflowPath string, userVars map[string]
 
 	envTasks := env.Workflow().GetTasks()
 	// TeardownEnvironment manages the envs.mu internally
-	err = envs.TeardownEnvironment(env.Id(), true/*force*/)
+	// We do not get the error here cause it overwrites the failed deployment error
+	// with <nil> which results to server.go to report back
+	// cannot get newly created environment: no environment with id <env id>
+	_ = envs.TeardownEnvironment(env.Id(), true/*force*/)
 
 	killedTasks, _, rlsErr := envs.taskman.KillTasks(envTasks.GetTaskIds())
 	if rlsErr != nil {
@@ -468,7 +471,7 @@ func (envs *Manager) CreateAutoEnvironment(workflowPath string, userVars map[str
 
 		envTasks := env.Workflow().GetTasks()
 		// TeardownEnvironment manages the envs.mu internally
-		err = envs.TeardownEnvironment(env.Id(), true/*force*/)
+		_ = envs.TeardownEnvironment(env.Id(), true/*force*/)
 
 		killedTasks, _, rlsErr := envs.taskman.KillTasks(envTasks.GetTaskIds())
 		if rlsErr != nil {

--- a/core/task/task.go
+++ b/core/task/task.go
@@ -499,7 +499,7 @@ func (t *Task) BuildPropertyMap(bindMap channel.BindMap) (propMap controlcommand
 					var chanProps controlcommands.PropertyMap
 					chanProps, err = outboundCh.ToFMQMap(bindMap)
 					if err != nil {
-						return nil, err
+						return nil, fmt.Errorf("task %s channel generation failed: %w", t.GetName(), err)
 					}
 
 					// And if valid, we copy it into the task's propertyMap

--- a/core/task/tasks.go
+++ b/core/task/tasks.go
@@ -109,7 +109,12 @@ func (m Tasks) BuildPropertyMaps(bindMap channel.BindMap) (propMapMap controlcom
 		}
 		receiver := task.GetMesosCommandTarget()
 
-		propMapMap[receiver] = task.BuildPropertyMap(bindMap)
+		var taskPropMap controlcommands.PropertyMap
+		taskPropMap, err = task.BuildPropertyMap(bindMap)
+		if err != nil {
+			return nil, err
+		}
+		propMapMap[receiver] = taskPropMap
 	}
 	return
 }


### PR DESCRIPTION
@miltalex this is https://alice.its.cern.ch/jira/browse/OCTRL-395

Currently the error message about a bad channel is pushed to InfoLogger, but the environment creation still ends with `code = Internal desc = cannot get newly created environment: no environment with id 2QoHfsQU9cB`.
This is not very nice, when an env creation fails in a non-recoverable fashion we should push the meaningful error message to the user.

I've followed the call stack up to `manager.go:789`, and apparently the returned `err` is pushed to the `internalEventCh`. I did not further investigate how to forward this event up to `server.go` and return it in response to the env create call. @miltalex since you're the expert on asynchronous `task.Manager` operation, could you please look into this and conclude OCTRL-395?

New error object under `error` here, it's then pushed to IL:
<img width="871" alt="Screenshot_20210503_111358" src="https://user-images.githubusercontent.com/126364/116859704-b2857400-ac00-11eb-9ba4-659d97940922.png">

To test, add repo `github.com/knopers8/ControlWorkflows` and deploy environment as test case (replace `centosvmtest2` with your host):
```
coconut env create -w github.com/knopers8/ControlWorkflows/workflows/readout-dataflow@fd8899fcb2747e8496771fe44bbbbed23e5c4b40 -e '{"hosts":"[\"centosvmtest2\"]","dcs_enabled":"false","odc_enabled":"false","qcdd_enabled":"false","dd_enabled":"true","minimal_dpl_enabled":"false","dpl_workflow":"minimal-dpl"}'
```