### PR TITLE
[apricot] Documentation for the Apricot TCE

### DIFF
--- a/apricot/doc/apricot.md
+++ b/apricot/doc/apricot.md
@@ -1,0 +1,20 @@
+## apricot
+
+**A** **p**rocessor and **r**epos**i**tory for **co**nfiguration **t**emplates
+
+### Synopsis
+
+The `o2-apricot` binary implements a centralized configuration (micro)service for ALICE O².
+
+### Usage and options
+
+```
+Usage of bin/o2-apricot:
+      --backendUri string   URI of the Consul server or YAML configuration file (default "consul://127.0.0.1:8500")
+      --listenPort int      Port of apricot server (default 32101)
+      --verbose             Verbose logging
+```
+
+### SEE ALSO
+
+* [apricot HTTP service](apricot_http_service.md) - make essential cluster information available via a web server

--- a/apricot/doc/apricot_http_service.md
+++ b/apricot/doc/apricot_http_service.md
@@ -12,12 +12,17 @@ To use this feature, the `o2-apricot` running machine has to communicate with Co
 
 ### Usage and options
 
-To retrieve the information needed regarding FLPs, use the following urls in a web browser.
+To retrieve the information needed regarding FLPs, use the following urls in a web browser or with `curl` or `wget`.
 
 To retrieve as plain text:
-* `your_machine/inventory/flps` or `your_machine/inventory/flps/text`
-* `/inventory/detectors/your_detector/flps` or `/inventory/detectors/your_detector/flps/text`
+* `http://<apricot-server>/inventory/flps` or `http://<apricot-server>/inventory/flps/text`
+* `http://<apricot-server>/inventory/detectors/<detector>/flps` or `http://<apricot-server>/inventory/detectors/<detector>/flps/text`
 
 To retrieve as JSON:
-* `your_machine/inventory/flps/json`
-* `/inventory/detectors/your_detector/flps/json`
+* `http://<apricot-server>/inventory/flps/json`
+* `http://<apricot-server>/inventory/detectors/<detector>/flps/json`
+
+### Examples
+
+* With `curl`: `curl http://localhost:32188/inventory/flps`
+* With `wget`: `wget http://localhost:32188/inventory/detectors/TST/flps/json -O ~/downloads/test`

--- a/apricot/doc/apricot_http_service.md
+++ b/apricot/doc/apricot_http_service.md
@@ -1,0 +1,23 @@
+## apricot HTTP service
+
+Web server component that implements the Trivial Configuration Endpoint (Apricot TCE). 
+
+It serves JSON and/or plain text structures in order to make essential cluster information available to scripts and other consumers for which the gRPC interface is impractical.
+
+It is strictly **read-only** and only ever responds to `GET`.
+
+### Configuration
+
+To use this feature, the `o2-apricot` running machine has to communicate with Consul via the `--backendUri` option (see [here](apricot.md)).
+
+### Usage and options
+
+To retrieve the information needed regarding FLPs, use the following urls in a web browser.
+
+To retrieve as plain text:
+* `your_machine/inventory/flps` or `your_machine/inventory/flps/text`
+* `/inventory/detectors/your_detector/flps` or `/inventory/detectors/your_detector/flps/text`
+
+To retrieve as JSON:
+* `your_machine/inventory/flps/json`
+* `/inventory/detectors/your_detector/flps/json`


### PR DESCRIPTION
The documentation explains how to use the Apricot TCE, which is an HTTP service providing read-only information on FLPs.