### PR TITLE
OCClite plugin: Release device control with the same plugin name as it was taken

### DIFF
--- a/occ/plugin/OccFMQCommon.cxx
+++ b/occ/plugin/OccFMQCommon.cxx
@@ -243,7 +243,7 @@ std::tuple<OccLite::nopb::TransitionResponse, ::grpc::Status> doTransition(fair:
     }
 
     if (newStates.back() == "EXITING") {
-        m_pluginServices->ReleaseDeviceControl("OCC");
+        m_pluginServices->ReleaseDeviceControl(FMQ_CONTROLLER_NAME);
         OLOG(debug) << "releasing device control";
     }
 


### PR DESCRIPTION
fix for [O2-2755](https://alice.its.cern.ch/jira/browse/O2-2755) with OCClite plugin. However, I have not been able to verify where the `SIGTERM` comes from and, given a graceful termination restored, whether this is enough to no longer trigger it.

Anyhow, with this change, I could gracefully shut down a test FairMQ device (`fairmq-bsampler`) with both OCC and OCClite plugins loaded and both with an `END` transition (sent via a locally modified `peanut` program) as well as with a `SIGTERM` from `IDLE` state.