### PR TITLE
Enable the mac build again

### DIFF
--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [macOS-latest, ubuntu-18.04]
         go: [ '1.17' ]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This reverts commit ac685b80b916ddb7cb99e04fe20802ad3dead8d2.

Since we moved to a different `kafka` package which does not contain C inside, we should be able to enable the mac build again.