### PR TITLE
[core] DCS override "ddl_list: default" with <detector>_default_ddl_list

### DIFF
--- a/core/integration/dcs/dcsutil.go
+++ b/core/integration/dcs/dcsutil.go
@@ -1,0 +1,51 @@
+/*
+ * === This file is part of ALICE O² ===
+ *
+ * Copyright 2022 CERN and copyright holders of ALICE O².
+ * Author: Teo Mrnjavac <teo.mrnjavac@cern.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In applying this license CERN does not waive the privileges and
+ * immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+package dcs
+
+import (
+	"strings"
+
+	dcspb "github.com/AliceO2Group/Control/core/integration/dcs/protos"
+	"github.com/sirupsen/logrus"
+)
+
+func resolveDefaults(detectorArgMap map[string]string, varStack map[string]string, det dcspb.Detector, theLog *logrus.Entry) map[string]string {
+	// Do we have any default expressions for defaultable values?
+	defaultableKeys := []string{"ddl_list"}
+
+	for _, key := range defaultableKeys {
+		if defaultableValue, ok := detectorArgMap[key]; ok {
+			if strings.TrimSpace(strings.ToLower(defaultableValue)) == "default" { // if one of the defaultable keys has value `default`...
+				defaultPayloadKey := strings.ToLower(det.String()) + "_default_" + key // e.g. tof_default_ddl_list
+				if defaultPayload, ok := varStack[defaultPayloadKey]; ok {
+					detectorArgMap[key] = defaultPayload
+				} else {
+					theLog.Warnf("requested default value for DCS parameter %s but no payload found at key %s: the string 'default' will be sent instead", key, defaultPayloadKey)
+				}
+			}
+		}
+	}
+	return detectorArgMap
+}

--- a/core/integration/dcs/plugin.go
+++ b/core/integration/dcs/plugin.go
@@ -308,6 +308,13 @@ func (p *Plugin) CallStack(data interface{}) (stack map[string]interface{}) {
 				return
 			}
 
+			// We parse the consolidated per-detector payload for any defaultable parameters with value "default"
+			detectorArgMap = resolveDefaults(detectorArgMap, varStack, det,
+				log.WithField("partition", envId).
+					WithField("call", "StartOfRun").
+					WithField("detector", det.String()).
+					WithField("runNumber", runNumber64))
+
 			in.Detectors[i] = &dcspb.DetectorOperationRequest{
 				Detector:        det,
 				ExtraParameters: detectorArgMap,


### PR DESCRIPTION
This currently only applies to the `ddl_list` entry within the DCS SOR payload variable, so the following vars are affected:
* `dcs_sor_parameters`
* `<det>_dcs_sor_parameters` where `<det>` is the lowercase 3LA of a detector, e.g. `mid`, `phs`, `tof`.

Within this context, if the SOR parameters payload for a given detector has a `ddl_list` entry with value `default` (string), the value is instead filled out with the content of the variable `<det>_default_ddl_list` (e.g. `mft_default_ddl_list`) if such a variable exists. Otherwise, the string `default` is kept and a warning is pushed to InfoLogger.

Any `eor_parameters` variables are unaffected.