### PR TITLE
[core] Kafka: Remove the deprecated PublishUpdate callback

### DIFF
--- a/core/integration/kafka/plugin.go
+++ b/core/integration/kafka/plugin.go
@@ -358,7 +358,6 @@ func (p *Plugin) CallStack(data interface{}) (stack map[string]interface{}) {
 
 	stack = make(map[string]interface{})
 	// The first two are actually equal. We create both to allow to migrate to a more accurate name.
-	stack["PublishUpdate"] = p.createNewStateCallback(varStack, "PublishUpdate")
 	stack["PublishEnterStateUpdate"] = p.createNewStateCallback(varStack, "PublishEnterStateUpdate")
 	stack["PublishLeaveStateUpdate"] = p.createLeaveStateCallback(varStack, "PublishLeaveStateUpdate")
 	return


### PR DESCRIPTION
It is replaced by a more precise name 'PublishEnterStateUpdate'. The old one is not used in ControlWorkflows for a few months.