### PR TITLE
[OCTRL-710][core] do not include newline char in JIT config queries

### DIFF
--- a/configuration/componentcfg/query.go
+++ b/configuration/componentcfg/query.go
@@ -65,6 +65,7 @@ func NewEntriesQuery(path string) (p *EntriesQuery, err error) {
 		RunType:   apricotpb.RunType_NULL,
 		RoleName:  "",
 	}
+	path = strings.TrimSpace(path)
 	if IsStringValidEntriesQueryPath(path) {
 		// coconut conf list component/FLAVOR/rolename
 		params := strings.Split(path, SEPARATOR)
@@ -101,6 +102,7 @@ func NewQuery(path string) (p *Query, err error) {
 		EntryKey:  "",
 		Timestamp: "",
 	}
+	path = strings.TrimSpace(path)
 	if IsStringValidQueryPathWithOptionalTimestamp(path) {
 		if strings.Contains(path, "@") {
 			// coconut conf show component/FLAVOR/rolename/entry@timestamp

--- a/configuration/template/dplutil.go
+++ b/configuration/template/dplutil.go
@@ -48,7 +48,7 @@ func jitDplGenerate(confSvc ConfigurationService, varStack map[string]string, wo
 	var metadata string
 
 	// Match any consul URL
-	re := regexp.MustCompile(`consul-json://[^ |]*`)
+	re := regexp.MustCompile(`consul-json://[^ |\n]*`)
 	matches := re.FindAllStringSubmatch(dplCommand, nMaxExpectedQcPayloads)
 
 	// Concatenate the consul LastIndex for each payload in a single string
@@ -60,6 +60,9 @@ func jitDplGenerate(confSvc ConfigurationService, varStack map[string]string, wo
 
 		// And query for Consul for its LastIndex
 		newQ, err := componentcfg.NewQuery(consulKey[1])
+		if err != nil {
+			return fmt.Sprintf("JIT could not create a query out of path '%s'. error: %e : "+err.Error(), consulKey[1])
+		}
 		_, lastIndex, err := confSvc.GetComponentConfigurationWithLastIndex(newQ)
 		if err != nil {
 			return fmt.Sprintf("JIT failed trying to query qc consul payload %s : "+err.Error(),


### PR DESCRIPTION
If the config file address was put at the end of JIT command, as below:
```
o2-qc --config json://path/to/payload
```
then the regex would include a newline character in the matched string,
which would not pass `inputFullRegex` when building a query. However,
we would try to retrieve the configuration anyway, because there was no
error check after invoking `NewQuery`.