### PR TITLE
[core] log task name when launching, do not log unknown fields

### DIFF
--- a/core/task/scheduler.go
+++ b/core/task/scheduler.go
@@ -862,13 +862,10 @@ func (state *schedulerState) resourceOffers(fidStore store.Singleton) events.Han
 						WithField("partition", envId.String()).
 						WithField("detector", descriptorDetector).
 						WithFields(logrus.Fields{
+							"name":       mesosTaskInfo.Name,
 							"taskId":     newTaskId,
 							"offerId":    offer.ID.Value,
 							"executorId": state.executor.ExecutorID.Value,
-							"command":    mesosTaskInfo.Command.GetValue(),
-							"arguments":  mesosTaskInfo.Command.GetArguments(),
-							"shenv":      mesosTaskInfo.Command.GetEnvironment().String(),
-							"user":       mesosTaskInfo.Command.GetUser(),
 						}).Debug("launching task")
 					taskPtr.SendEvent(&event.TaskEvent{Name: taskPtr.GetName(), TaskID: newTaskId, State: "LAUNCHED", Hostname: taskPtr.hostname, ClassName: taskPtr.GetClassName()})
 


### PR DESCRIPTION
It is very hard to understand what we are launching when seeing this log:
```
launching task arguments="[]" command="" executorId="2b64uRrAZLV" offerId="32d772d9-0b53-4993-89b8-5cbba97fd25c-O5319787" shenv="nil" taskId="2bNEDDC1JkH" user=""
```
At this stage the fields arguments, command, user and shenv are not even set, so reporting them does not make sense, while we could log task name, which is very helpful to know. The log after changes looks as follows:
```
launching task executorId="2bNyeXqPrzr" name="github.com/AliceO2Group/ControlWorkflows/tasks/fairmq-shmmonitor@6431d49d86ef219fad559510e400b98a7b6ba48f?2bNyeXqQCUn" offerId="d821eca9-76fa-44c8-8d76-2cfd3d7bfa51-O1467528" taskId="2bNyeXqQCUn"
```