### PR TITLE
[executor] do not try to recover a task in error, ask to exit instead

### DIFF
--- a/executor/executable/controllabletask.go
+++ b/executor/executable/controllabletask.go
@@ -614,8 +614,8 @@ func (t *ControllableTask) Kill() error {
 				evt = "RESET"
 				destination = "STANDBY"
 			case "ERROR":
-				evt = "RECOVER"
-				destination = "STANDBY"
+				evt = "EXIT"
+				destination = "DONE"
 			case "STANDBY":
 				evt = "EXIT"
 				destination = "DONE"

--- a/occ/occlib/OccServer.cxx
+++ b/occ/occlib/OccServer.cxx
@@ -344,6 +344,13 @@ t_State OccServer::processStateTransition(const std::string& event, const boost:
             } else {
                 newState=t_State::error;
             }
+        } else if (evt=="exit") {
+            err = m_rco->executeExit();
+            if (!err) {
+                newState = t_State::done;
+            } else {
+                newState = t_State::error;
+            }
         } else {
             invalidEvent=1;
         }


### PR DESCRIPTION
Could not test every possible scenario, but it seems to be fine.