### PR TITLE
[core] 'task inactive exception' should be an error log

### DIFF
--- a/core/task/manager.go
+++ b/core/task/manager.go
@@ -1039,8 +1039,8 @@ func (m *Manager) handleMessage(tm *TaskmanMessage) error {
 					"message": mesosStatus.GetMessage(),
 					"level":   infologger.IL_Devel,
 				}).
-				WithField("partition", tm.GetEnvironmentId().String()).
-				Info("task inactive exception")
+				WithField("partition", tm.GetEnvironmentId().String()). // fixme: this is empty!
+				Error("task inactive exception")
 			taskIDValue := mesosStatus.GetTaskID().Value
 			t := m.GetTask(taskIDValue)
 			if t != nil && t.IsLocked() {


### PR DESCRIPTION
Sometimes this is the only message from aliecs to know which task failed. It is easy to miss when it is Info. It would be even better if it had partition id included, but did not find a way to retrieve it, it is not there even in Labels.