### PR TITLE
[executor] truncate task command in logs when it will be cut

### DIFF
--- a/executor/executable/hooktask.go
+++ b/executor/executable/hooktask.go
@@ -36,7 +36,7 @@ func (t *HookTask) makeTransitionFunc() transitioner.DoTransitionFunc {
 	// NOOP transition function, because hooks don't obey any transition
 	return func(ei transitioner.EventInfo) (newState string, err error) {
 		log.WithField("partition", t.knownEnvironmentId.String()).
-			WithField("partition", t.knownDetector).
+			WithField("detector", t.knownDetector).
 			WithField("event", ei.Evt).
 			Debug("executor hook task transitioner requesting transition")
 

--- a/executor/executable/task.go
+++ b/executor/executable/task.go
@@ -102,10 +102,12 @@ func NewTask(taskInfo mesos.TaskInfo, sendStatusFunc SendStatusFunc, sendDeviceE
 			Debug("instantiating task")
 
 		rawCommand := strings.Join(append([]string{*commandInfo.Value}, commandInfo.Arguments...), " ")
+		// we deliberately print taskID, then command, so if the latter is too long for infologger to accept it,
+		// we at least have the taskID and the beginning of the command.
 		log.WithField("level", infologger.IL_Support).
 			WithField("partition", envId.String()).
 			WithField("detector", detector).
-			Infof("launching task %s", rawCommand)
+			Infof("launching task %s: %s", taskInfo.TaskID.GetValue(), rawCommand)
 	} else {
 		if err != nil {
 			log.WithError(err).

--- a/executor/handlers.go
+++ b/executor/handlers.go
@@ -244,7 +244,6 @@ func handleLaunchEvent(state *internalState, taskInfo mesos.TaskInfo) error {
 	detector := executorutil.GetValueFromLabelerType(&taskInfo, "detector")
 
 	log.WithFields(logrus.Fields{
-		"cmd":       taskInfo.Command.GetValue(),
 		"taskId":    taskInfo.TaskID.GetValue(),
 		"taskName":  taskInfo.Name,
 		"hostname":  state.agent.GetHostname(),
@@ -256,7 +255,6 @@ func handleLaunchEvent(state *internalState, taskInfo mesos.TaskInfo) error {
 	defer utils.TimeTrack(time.Now(),
 		"executor.handleLaunchEvent",
 		log.WithFields(logrus.Fields{
-			"cmd":       taskInfo.Command.GetValue(),
 			"taskId":    taskInfo.TaskID.GetValue(),
 			"taskName":  taskInfo.Name,
 			"hostname":  state.agent.GetHostname(),
@@ -285,7 +283,6 @@ func handleLaunchEvent(state *internalState, taskInfo mesos.TaskInfo) error {
 		state.activeTasks[taskInfo.TaskID] = myTask
 		state.activeTasksMu.Unlock()
 		log.WithFields(logrus.Fields{
-			"cmd":       taskInfo.Command.GetValue(),
 			"taskId":    taskInfo.TaskID.GetValue(),
 			"taskName":  taskInfo.Name,
 			"hostname":  state.agent.GetHostname(),
@@ -298,7 +295,6 @@ func handleLaunchEvent(state *internalState, taskInfo mesos.TaskInfo) error {
 		// If Launch returned non-nil error, it should already have sent back a status update
 		log.WithError(err).
 			WithFields(logrus.Fields{
-				"cmd":       taskInfo.Command.GetValue(),
 				"taskId":    taskInfo.TaskID.GetValue(),
 				"taskName":  taskInfo.Name,
 				"hostname":  state.agent.GetHostname(),


### PR DESCRIPTION
This truncates the long DPL commands to leave the part after the last pipe, which is the most crucial to understand what is running. We attempt to print the full command in "launching task" log. Also, the PR removes "cmd" field in logs where it is empty anyway.