### PR TITLE
[OCTRL-704][core] template helpers for assigning JIT workflows per groups of FLPs

### DIFF
--- a/configuration/template/stack.go
+++ b/configuration/template/stack.go
@@ -319,9 +319,9 @@ func MakeUtilFuncMap(varStack map[string]string) map[string]interface{} {
 			}
 			return *in
 		},
-		"HostnameWithin": func(hostname string, prefix string, idMinStr string, idMaxStr string) string {
-			trimmed := strings.TrimPrefix(hostname, prefix)
-			if hostname == trimmed {
+		"SuffixInRange": func(input string, prefix string, idMinStr string, idMaxStr string) string {
+			trimmed := strings.TrimPrefix(input, prefix)
+			if input == trimmed {
 				return "false"
 			}
 			id, err := strconv.Atoi(trimmed)
@@ -330,12 +330,12 @@ func MakeUtilFuncMap(varStack map[string]string) map[string]interface{} {
 			}
 			idMin, err := strconv.Atoi(idMinStr)
 			if err != nil {
-				log.Errorf("Argument idMinStr to HostnameWithin is not a number: %s", idMinStr)
+				log.Errorf("Argument idMinStr to SuffixInRange is not a number: %s", idMinStr)
 				return "false"
 			}
 			idMax, err := strconv.Atoi(idMaxStr)
 			if err != nil {
-				log.Errorf("Argument idMaxStr to HostnameWithin is not a number: %s", idMaxStr)
+				log.Errorf("Argument idMaxStr to SuffixInRange is not a number: %s", idMaxStr)
 				return "false"
 			}
 


### PR DESCRIPTION
Here is an example of how they could be used: https://github.com/AliceO2Group/ControlWorkflows/pull/533/files

I hope that `HostnameWithin` reduces 150 string comparisons and `and` operations into a few for each FLP. In principle, we could even compare raw strings with IDs without converting them, assuming they use leading zeros, but I am not sure I want to risk it.