### PR TITLE
[core] LeafWalk should also walk in include roles

### DIFF
--- a/core/workflow/roleutils.go
+++ b/core/workflow/roleutils.go
@@ -74,6 +74,11 @@ func Walk(root Role, do func(role Role)) {
 		for _, child := range typed.Roles {
 			LeafWalk(child, do)
 		}
+	case *includeRole:
+		do(typed)
+		for _, child := range typed.Roles {
+			Walk(child, do)
+		}
 	case *taskRole:
 		do(typed)
 	case *callRole:
@@ -88,6 +93,10 @@ func LeafWalk(root Role, do func(role Role)) {
 			LeafWalk(child, do)
 		}
 	case *iteratorRole:
+		for _, child := range typed.Roles {
+			LeafWalk(child, do)
+		}
+	case *includeRole:
 		for _, child := range typed.Roles {
 			LeafWalk(child, do)
 		}


### PR DESCRIPTION
This fixes error messages with missing failed roles:
```
cannot create new environment: transition canceled with error: workflow deployment failed, aborting and cleaning up [failed roles: ]
```
Here it is with the fix:
```
cannot create new environment: transition canceled with error: workflow deployment failed, aborting and cleaning up [failed roles: readout-dataflow.host-piotr-ostack3.data-distribution-dpl.dpl.internal-dpl-injected-dummy-sink]
```