### PR TITLE
[QC-902] tune OCC log levels

### DIFF
--- a/occ/plugin/OccLiteServer.cxx
+++ b/occ/plugin/OccLiteServer.cxx
@@ -79,14 +79,14 @@ OccLite::Service::Service(fair::mq::PluginServices* pluginServices)
     (void) context;
     (void) request;
 
-    OLOG(info) << "Incoming GetState request: " << request->JsonMessage::Serialize();
+    OLOG(detail) << "Incoming GetState request: " << request->JsonMessage::Serialize();
 
     auto state = fair::mq::PluginServices::ToStr(m_pluginServices->GetCurrentDeviceState());
     pid_t pid = getpid();
 
     response->state = state;
     response->pid = pid;
-    OLOG(info) << "GetState response: " << response->state;
+    OLOG(detail) << "GetState response: " << response->state;
 
     return grpc::Status::OK;
 }
@@ -95,7 +95,7 @@ OccLite::Service::Service(fair::mq::PluginServices* pluginServices)
                                             const OccLite::nopb::TransitionRequest* request,
                                             OccLite::nopb::TransitionResponse* response)
 {
-    OLOG(info) << "Incoming Transition request: " << request->JsonMessage::Serialize();
+    OLOG(detail) << "Incoming Transition request: " << request->JsonMessage::Serialize();
 
     auto transitionOutcome = doTransition(m_pluginServices, *request);
     ::grpc::Status grpcStatus = std::get<1>(transitionOutcome);
@@ -106,7 +106,7 @@ OccLite::Service::Service(fair::mq::PluginServices* pluginServices)
 
     auto nopbResponse = std::get<0>(transitionOutcome);
     *response = nopbResponse;
-    OLOG(info) << "Transition response: " << response->state << " ok: " << response->ok;
+    OLOG(detail) << "Transition response: " << response->state << " ok: " << response->ok;
 
     return grpc::Status::OK;
 }

--- a/occ/plugin/litestructs/JsonMessage.cxx
+++ b/occ/plugin/litestructs/JsonMessage.cxx
@@ -62,7 +62,7 @@ bool OccLite::nopb::JsonMessage::Deserialize(::grpc::ByteBuffer* byte_buffer)
     auto status = byte_buffer->Dump(slices);
 
     if (!status.ok()) {
-        OLOG(info) << "Cannot dump JsonMessage slices, error code " << status.error_code() << " " << status.error_message() << " " << status.error_details();
+        OLOG(error) << "Cannot dump JsonMessage slices, error code " << status.error_code() << " " << status.error_message() << " " << status.error_details();
         return false;
     }
 
@@ -74,7 +74,7 @@ bool OccLite::nopb::JsonMessage::Deserialize(::grpc::ByteBuffer* byte_buffer)
         ::grpc::g_core_codegen_interface->grpc_slice_unref(rawSlice);
     }
 
-    OLOG(info) << "Deserialized JsonMessage: " << ss.str();
+    OLOG(detail) << "Deserialized JsonMessage: " << ss.str();
 
     return Deserialize(ss.str());
 }
@@ -82,7 +82,7 @@ bool OccLite::nopb::JsonMessage::Deserialize(::grpc::ByteBuffer* byte_buffer)
 ::grpc::ByteBuffer* OccLite::nopb::JsonMessage::SerializeToByteBuffer() const
 {
     std::string str = Serialize();
-    OLOG(info) << "Serialized JsonMessage: " << str;
+    OLOG(detail) << "Serialized JsonMessage: " << str;
 
     // grpc::string = std::string
     // We build a Slice(grpc::string) and we add it to the ByteBuffer

--- a/occ/plugin/litestructs/Transition.cxx
+++ b/occ/plugin/litestructs/Transition.cxx
@@ -56,7 +56,7 @@ bool OccLite::nopb::TransitionRequest::Deserialize(const rapidjson::Value& obj)
             arguments.push_back(*ce);
         }
     }
-    OLOG(info) << "Deserialized TransitionRequest: " << JsonMessage::Serialize();
+    OLOG(detail) << "Deserialized TransitionRequest: " << JsonMessage::Serialize();
 
     return true;
 }


### PR DESCRIPTION
info becomes detail, which should be translated to IL's debug, but in contrast to FairLogger's debug, it should appear in Release builds.

Needs https://github.com/AliceO2Group/AliceO2/pull/10615