### PR TITLE
[OCTRL-683][executor] ERROR should not be the last state

### DIFF
--- a/executor/executable/controllabletask.go
+++ b/executor/executable/controllabletask.go
@@ -672,8 +672,7 @@ func (t *ControllableTask) Kill() error {
 			return
 		}
 
-		for reachedState != "DONE" &&
-			reachedState != "ERROR" {
+		for reachedState != "DONE" {
 			cmd := nextTransition(reachedState)
 			log.WithField("partition", t.knownEnvironmentId.String()).
 				WithField("detector", t.knownDetector).


### PR DESCRIPTION
Since we aim to transition from ERROR to DONE, we cannot stop the loop when we reach ERROR. KILL_TRANSITION_TIMEOUT should protect us from being stuck in ERROR forever (in case we fail to get to DONE).