### PR TITLE
[core] do not complain when ccdb plugin cannot get a run number

### DIFF
--- a/core/integration/ccdb/plugin.go
+++ b/core/integration/ccdb/plugin.go
@@ -117,7 +117,7 @@ func NewGRPObject(varStack map[string]string) *GeneralRunParameters {
 	if !ok {
 		log.WithField("level", infologger.IL_Support).
 			WithField("partition", envId).
-			Error("cannot acquire run number for GRP object")
+			Debug("cannot acquire run number for GRP object")
 		return nil
 	}
 	runNumber, err := strconv.ParseUint(runNumberStr, 10, 32)


### PR DESCRIPTION
Now it is perfectly legal to not be able to acquire a run number, since the plugin is called also at GO_ERROR and DESTROY, which might not necessarily happen while in RUNNING.