### PR TITLE
[O2-2818][core] Disable autoBind in FairMQ

### DIFF
--- a/core/task/channel/inbound.go
+++ b/core/task/channel/inbound.go
@@ -152,19 +152,20 @@ func (inbound *Inbound) buildFMQMap(address string, transport TransportType) (pm
 	prefix := strings.Join([]string{chans, chName, "0"}, ".")
 
 	chanProps := controlcommands.PropertyMap{
-		"address": address,
-		"method": "bind",
-		"rateLogging": inbound.RateLogging,
-		"rcvBufSize": strconv.Itoa(inbound.RcvBufSize),
+		"address":       address,
+		"method":        "bind",
+		"autoBind":      "false",
+		"rateLogging":   inbound.RateLogging,
+		"rcvBufSize":    strconv.Itoa(inbound.RcvBufSize),
 		"rcvKernelSize": "0", //NOTE: hardcoded
-		"sndBufSize": strconv.Itoa(inbound.SndBufSize),
+		"sndBufSize":    strconv.Itoa(inbound.SndBufSize),
 		"sndKernelSize": "0", //NOTE: hardcoded
-		"transport": transport.String(),
-		"type": inbound.Type.String(),
+		"transport":     transport.String(),
+		"type":          inbound.Type.String(),
 	}
 
 	for k, v := range chanProps {
-		pm[prefix + "." + k] = v
+		pm[prefix+"."+k] = v
 	}
 	return
 }


### PR DESCRIPTION
This makes FairMQ produce an error when failing to bind a port instead of selecting a random one in the range 22000-23000, which is useless in our case.

Probably not related to OCTRL-773, but should fix O2-2818, where we obliviously run a QC proxy which could not bind a port due to a leftover task on the same machine.