### PR TITLE
Enable trace logs when core is run with --veryVerbose

### DIFF
--- a/common/logger/infologger/directhook.go
+++ b/common/logger/infologger/directhook.go
@@ -171,7 +171,7 @@ func (h *DirectHook) Levels() []logrus.Level {
 		logrus.WarnLevel,
 		logrus.InfoLevel,
 		logrus.DebugLevel,
-		// logrus.TraceLevel,
+		logrus.TraceLevel,
 	}
 }
 


### PR DESCRIPTION
The already existing infrastructure can map logrus' TraceLevel to InfoLogger's Debug severity and Trace level. Also, Trace logs are enabled only if the core is ran with --veryVerbose, however, they are not propagated to InfoLogger. This commit enables the propagation of Trace logs to InfoLogger. I expect the impact to be minimal, as we run with --veryVerbose only when really needed and mostly in development setups. It is not aimed to be the default mode to operate with.

This commit should have no effect on the logs from executor, as it is always ran with Debug level.