### PR TITLE
[core] remove obsolete workaround to make ERROR state always win

### DIFF
--- a/core/workflow/safestate.go
+++ b/core/workflow/safestate.go
@@ -39,7 +39,6 @@ func aggregateState(roles []Role) (state task.State) {
 	if len(roles) == 0 {
 		return
 	}
-	var hasBeenInError = false
 	for _, c := range roles {
 		taskR, isTaskRole := c.(*taskRole)
 		callR, isCallRole := c.(*callRole)
@@ -52,13 +51,7 @@ func aggregateState(roles []Role) (state task.State) {
 				continue
 			}
 		}
-		if c.GetState() == task.ERROR {
-			hasBeenInError = true
-		}
 		state = state.X(c.GetState())
-	}
-	if hasBeenInError && state == task.MIXED {
-		state = task.ERROR
 	}
 	return
 }


### PR DESCRIPTION
As far as I understand, this was an attempt at fixing the cases when ERROR state is overriden by MIXED, which was fixed in https://github.com/AliceO2Group/Control/pull/535 and https://github.com/AliceO2Group/Control/pull/536 directly in the state arithmetics code. I don't think this is needed anymore and happy tests seem to confirm it.