### PR TITLE
[core] keeping created kafka writers in global object

### DIFF
--- a/common/event/writer.go
+++ b/common/event/writer.go
@@ -56,6 +56,10 @@ func NewWriterWithTopic(topic topic.Topic) *Writer {
 	}
 }
 
+func (w *Writer) Close() {
+	w.Close()
+}
+
 func (w *Writer) WriteEvent(e interface{}) {
 	w.WriteEventWithTimestamp(e, time.Now())
 }

--- a/core/core.go
+++ b/core/core.go
@@ -112,6 +112,7 @@ func Run() error {
 
 	// Ensure all workflow plugins are destroyed before core teardown
 	integration.PluginsInstance().DestroyAll()
+	the.ClearEventWriters()
 
 	return err
 }


### PR DESCRIPTION
This is probably not the best way how to fix the issue of creating kafka writers every time we want to send the message. But I am using it as a draft to demonstrate the fix in the ticket. We will discuss with @knopers8 whether this is the best way to fix this.