### PR TITLE
[core] Added missing mutex around eventStream in environment

### DIFF
--- a/core/environment/environment.go
+++ b/core/environment/environment.go
@@ -122,6 +122,8 @@ func newEnvironment(userVars map[string]string, newId uid.ID) (env *Environment,
 		func() gera.StringMap { return env.GlobalVars },
 		func() gera.StringMap { return env.UserVars },
 		func(ev event.Event) {
+			env.Mu.Lock()
+			defer env.Mu.Unlock()
 			if env.eventStream != nil {
 				env.eventStream.Send(ev)
 			}


### PR DESCRIPTION
While searching for the cause of [OCTRL-882](https://its.cern.ch/jira/browse/OCTRL-882) I found this error with missing mutex around channel write. It is in the middle of all the symptoms (more in the ticket), so it even might be the cause of the issue, but I cannot be sure about that without more information when the aliecs gets stuck.

As I cannot be sure that this PR will fix mentioned bug, I propose to keep this PR not merged until we will be able to demonstrate the issue with somebody being able to `delve` into the aliecs status while it gets stuck and get stack trace of all of goroutines.