### PR TITLE
[core] inform, not warn if there is one executor on a node

### DIFF
--- a/core/task/scheduler.go
+++ b/core/task/scheduler.go
@@ -635,7 +635,7 @@ func (state *schedulerState) resourceOffers(fidStore store.Singleton) events.Han
 								log.WithField("executorId", targetExecutorId.Value).
 									WithField("offerHost", offer.GetHostname()).
 									WithField("level", infologger.IL_Support).
-									Warn("received offer with one executor ID, will use existing executor")
+									Info("received offer with one executor ID, will use existing executor")
 							} else if len(offer.ExecutorIDs) > 1 {
 								log.WithField("executorId", targetExecutorId.Value).
 									WithField("executorIds", offer.ExecutorIDs).


### PR DESCRIPTION
which is perfectly expected situation.