### PR TITLE
OCTRL-888 [occ] If we see FairMQ's ERROR state, we should exit

### DIFF
--- a/occ/plugin/OccLiteServer.cxx
+++ b/occ/plugin/OccLiteServer.cxx
@@ -130,8 +130,9 @@ OccLite::Service::EventStream(::grpc::ServerContext* context, const OccLite::nop
         last_known_state = state;
 
         OLOG(debug) << "[EventStream] new state: " << state;
-
-        if (state == "EXITING") {
+        // for FairMQ, EXITING and ERROR are both final states and plugins are expected to quit at this point
+        // see octrl-888 for more details
+        if (state == "EXITING" || state == "ERROR") {
             std::unique_lock<std::mutex> finished_lk(finished_mu);
 
             auto nilEvent = new nopb::DeviceEvent;


### PR DESCRIPTION
FairMQ considers ERROR state as a final state and expects any plugins to exit in such case. This is of course in contradiction to our concept of the ERROR state, which we envisage to RECOVER from. This being said, since FairMQ tries to exit anyway in such cases and we do not plan to work on recovery soon, I think the best is to respect the current status quo. This fixes OCTRL-888, allowing the DPL tasks to exit upon seeing an exception and propagating it to FairMQ.