### PR TITLE
OCTRL-893 [core] always log why the environment goes into ERROR

### DIFF
--- a/core/environment/environment.go
+++ b/core/environment/environment.go
@@ -952,6 +952,9 @@ func (env *Environment) subscribeToWfState(taskman *task.Manager) {
 							handlingError = true
 
 							time.AfterFunc(500*time.Millisecond, func() { // wait 0.5s for any other tasks to go to ERROR/INACTIVE
+								log.WithField("partition", env.id).
+									WithField("level", infologger.IL_Ops).
+									Warn("one of the critical tasks went into ERROR state, transitioning the environment into ERROR")
 								err := env.TryTransition(NewGoErrorTransition(taskman))
 								if err != nil {
 									log.WithField("partition", env.id).

--- a/core/server.go
+++ b/core/server.go
@@ -586,6 +586,10 @@ func (m *RpcServer) ControlEnvironment(cxt context.Context, req *pb.ControlEnvir
 	td := eot.Sub(sot)
 
 	if err != nil {
+		log.WithField("partition", env.Id()).
+			WithField("level", infologger.IL_Ops).
+			WithError(err).
+			Errorf("transition '%s' failed, transitioning into ERROR.", req.GetType().String())
 		err = env.TryTransition(environment.NewGoErrorTransition(m.state.taskman))
 		if err != nil {
 			log.WithField("partition", env.Id()).Warnf("could not complete requested GO_ERROR transition, forcing move to ERROR: %s", err.Error())

--- a/core/workflow/callrole.go
+++ b/core/workflow/callrole.go
@@ -26,6 +26,7 @@ package workflow
 
 import (
 	"errors"
+	"github.com/AliceO2Group/Control/common/logger/infologger"
 	"strings"
 	texttemplate "text/template"
 	"time"
@@ -249,6 +250,13 @@ func (t *callRole) updateState(s task.State) {
 			RolePath:      t.GetPath(),
 			EnvironmentId: t.GetEnvironmentId().String(),
 		})
+		if t.state.get() == task.ERROR {
+			log.WithField("partition", t.GetEnvironmentId().String()).
+				WithField("level", infologger.IL_Support).
+				WithField("role", t.Name).
+				WithField("critical", t.Critical).
+				Error("call went into ERROR")
+		}
 	}
 	t.SendEvent(&event.RoleEvent{Name: t.Name, State: t.state.get().String(), RolePath: t.GetPath()})
 

--- a/core/workflow/taskrole.go
+++ b/core/workflow/taskrole.go
@@ -26,6 +26,7 @@ package workflow
 
 import (
 	"errors"
+	"github.com/AliceO2Group/Control/common/logger/infologger"
 	"strings"
 	texttemplate "text/template"
 	"time"
@@ -253,6 +254,13 @@ func (t *taskRole) updateState(s task.State) {
 			RolePath:      t.GetPath(),
 			EnvironmentId: t.GetEnvironmentId().String(),
 		})
+		if t.state.get() == task.ERROR {
+			log.WithField("partition", t.GetEnvironmentId().String()).
+				WithField("level", infologger.IL_Support).
+				WithField("role", t.Name).
+				WithField("critical", t.Critical).
+				Error("task went into ERROR")
+		}
 	}
 	t.SendEvent(&event.RoleEvent{Name: t.Name, State: t.state.get().String(), RolePath: t.GetPath()})
 


### PR DESCRIPTION
A bunch of easy improvements to better know why an environment goes into error:
- whenever a task goes to error, it is logged
- whenever we create a new error transition, we log what led us to it