### PR TITLE
OCTRL-901 Document the order of actions performed during SOR and EOR

### DIFF
--- a/docs/handbook/operation_order.md
+++ b/docs/handbook/operation_order.md
@@ -21,18 +21,10 @@ This is the order of actions happening at a healthy start of run.
   - `kafka.PublishStartActivityUpdate()` at `-50`
   - `dcs.StartOfRun()`, `odc.Start()` (does not need to return now), `ccdb.RunStart()` at `0`
 
-### before_event
-
-- `before_event` hooks are executed
-
 ### leave_CONFIGURED
 
 - `leave_CONFIGURED` hooks are executed
   - `kafka.PublishLeaveStateUpdate()` at `0`
-
-### leave_state
-
-- `leave_state` hooks are executed
 
 ### Transition START_ACTIVITY
 
@@ -45,20 +37,12 @@ This is the order of actions happening at a healthy start of run.
 - `enter_RUNNING` hooks are executed
   - `o2-roc-ctp-emulator` for all ROC CTP emulator endpoints, `kafka.PublishEnterStateUpdate()` at `0`
 
-### enter_state
-
-- `enter_state` hooks are executed
-
 ### after_START_ACTIVITY
 - `"run_start_completion_time_ms"` is set using current time. It is considered as the EOSOR timestamp.
 - `after_START_ACTIVITY` hooks are executed:
   - `trg.RunStart()` at `0`
   - waiting until `odc.Start()` executed at `before_START_ACTIVITY` completes at `0`
   - `bookkeeping.UpdateRunStart()`, `bookkeeping.UpdateEnv()` at `+100`
-
-### after_event
-
-- `after_event` hooks are executed
 
 ## STOP_ACTIVITY (End Of Run)
 
@@ -70,18 +54,10 @@ This is the order of actions happening at a healthy end of run.
 - `before_STOP_ACTIVITY` hooks are executed:
   - `trg.RunStop()`, `odc.Stop()` (does not need to return now) at `0`
 
-### before_event
-
-- `before_event` hooks are executed
-
 ### leave_RUNNING
 
 - `leave_RUNNING` hooks are executed
   - `kafka.PublishLeaveStateUpdate()` at `0`
-
-### leave_state
-
-- `leave_state` hooks are executed
 
 ### Transition STOP_ACTIVITY
 
@@ -93,10 +69,6 @@ This is the order of actions happening at a healthy end of run.
 - `enter_CONFIGURED` hooks are executed
   - `kafka.PublishEnterStateUpdate()` at `0`
 
-### enter_state
-
-- `enter_state` hooks are executed
-
 ### after_STOP_ACTIVITY
 - `"run_end_completion_time_ms"` is set using current time. It is considered as the EOEOR timestamp.
 - `after_STOP_ACTIVITY` hooks are executed:
@@ -104,7 +76,3 @@ This is the order of actions happening at a healthy end of run.
   - `ccdb.RunStop()`, `dcs.EndOfRun()` at `0`
   - waiting until `odc.Stop()()` executed at `before_STOP_ACTIVITY` completes at `0`
   - `bookkeeping.UpdateRunStop()`, `bookkeeping.UpdateEnv()` at `+100`
-
-### after_event
-
-- `after_event` hooks are executed

--- a/docs/handbook/operation_order.md
+++ b/docs/handbook/operation_order.md
@@ -61,7 +61,7 @@ This is the order of actions happening at a healthy end of run.
 
 ### Transition STOP_ACTIVITY
 
-- Tasks are transitioned to `STOP`
+- Tasks are transitioned to `CONFIGURED`
 - If everything succeeds up to this point, we consider that the run has stopped
 
 ### enter_CONFIGURED

--- a/docs/handbook/operation_order.md
+++ b/docs/handbook/operation_order.md
@@ -1,10 +1,10 @@
 # Environment operation order
 
 This chapter attempts to document the order of important operations done during environment transitions.
-Since AliECS is an evolving system, the information presented here might be out-of-date, thus please refer to event handling in [core/environment/environment.go](core/environment/environment.go) and plugin calls in [ControlWorkflows/workflows/readout-dataflow.yaml](https://github.com/AliceO2Group/ControlWorkflows/blob/master/workflows/readout-dataflow.yaml) for the ultimate source of truth.
+Since AliECS is an evolving system, the information presented here might be out-of-date, thus please refer to event handling in [core/environment/environment.go](https://github.com/AliceO2Group/Control/blob/master/core/environment/environment.go) and plugin calls in [ControlWorkflows/workflows/readout-dataflow.yaml](https://github.com/AliceO2Group/ControlWorkflows/blob/master/workflows/readout-dataflow.yaml) for the ultimate source of truth.
 Also, please report to the ECS developers any inaccuracies.
 
-[State Machine Callbacks](docs/handbook/configuration.md#State-machine-callbacks) documents the order of callbacks that can be associated with state machine transitions.
+[State Machine Callbacks](configuration.md#State-machine-callbacks) documents the order of callbacks that can be associated with state machine transitions.
 
 ## START_ACTIVITY (Start Of Run)
 

--- a/docs/handbook/operation_order.md
+++ b/docs/handbook/operation_order.md
@@ -1,0 +1,110 @@
+# Environment operation order
+
+This chapter attempts to document the order of important operations done during environment transitions.
+Since AliECS is an evolving system, the information presented here might be out-of-date, thus please refer to event handling in [core/environment/environment.go](core/environment/environment.go) and plugin calls in [ControlWorkflows/workflows/readout-dataflow.yaml](https://github.com/AliceO2Group/ControlWorkflows/blob/master/workflows/readout-dataflow.yaml) for the ultimate source of truth.
+Also, please report to the ECS developers any inaccuracies.
+
+[State Machine Callbacks](docs/handbook/configuration.md#State-machine-callbacks) documents the order of callbacks that can be associated with state machine transitions.
+
+## START_ACTIVITY (Start Of Run)
+
+This is the order of actions happening at a healthy start of run.
+
+### before_START_ACTIVITY
+
+- `"run_number"` is set.
+- `"run_start_time_ms"` is set using the current time. It is considered as the SOR and SOSOR timestamps.
+- `before_START_ACTIVITY` hooks are executed:
+  - `trg.PrepareForRun()` at `-200`
+  - `trg.RunLoad()`, `bookkeeping.StartOfRun()` at `-100`
+  - `bookkeeping.RetrieveFillInfo()` at `-99`
+  - `kafka.PublishStartActivityUpdate()` at `-50`
+  - `dcs.StartOfRun()`, `odc.Start()` (does not need to return now), `ccdb.RunStart()` at `0`
+
+### before_event
+
+- `before_event` hooks are executed
+
+### leave_CONFIGURED
+
+- `leave_CONFIGURED` hooks are executed
+  - `kafka.PublishLeaveStateUpdate()` at `0`
+
+### leave_state
+
+- `leave_state` hooks are executed
+
+### Transition START_ACTIVITY
+
+- Fill Info previously retrieved by the BKP plugin is read from the variable stack and put into transition message to tasks
+- Tasks are transitioned to `RUNNING`
+- If everything succeeds up to this point, we report that the run has started
+
+### enter_RUNNING
+
+- `enter_RUNNING` hooks are executed
+  - `o2-roc-ctp-emulator` for all ROC CTP emulator endpoints, `kafka.PublishEnterStateUpdate()` at `0`
+
+### enter_state
+
+- `enter_state` hooks are executed
+
+### after_START_ACTIVITY
+- `"run_start_completion_time_ms"` is set using current time. It is considered as the EOSOR timestamp.
+- `after_START_ACTIVITY` hooks are executed:
+  - `trg.RunStart()` at `0`
+  - waiting until `odc.Start()` executed at `before_START_ACTIVITY` completes at `0`
+  - `bookkeeping.UpdateRunStart()`, `bookkeeping.UpdateEnv()` at `+100`
+
+### after_event
+
+- `after_event` hooks are executed
+
+## STOP_ACTIVITY (End Of Run)
+
+This is the order of actions happening at a healthy end of run.
+
+### before_STOP_ACTIVITY
+
+- `"run_end_time_ms"` is set using the current time. It is considered as the EOR and SOEOR timestamps.
+- `before_STOP_ACTIVITY` hooks are executed:
+  - `trg.RunStop()`, `odc.Stop()` (does not need to return now) at `0`
+
+### before_event
+
+- `before_event` hooks are executed
+
+### leave_RUNNING
+
+- `leave_RUNNING` hooks are executed
+  - `kafka.PublishLeaveStateUpdate()` at `0`
+
+### leave_state
+
+- `leave_state` hooks are executed
+
+### Transition STOP_ACTIVITY
+
+- Tasks are transitioned to `STOP`
+- If everything succeeds up to this point, we consider that the run has stopped
+
+### enter_CONFIGURED
+
+- `enter_CONFIGURED` hooks are executed
+  - `kafka.PublishEnterStateUpdate()` at `0`
+
+### enter_state
+
+- `enter_state` hooks are executed
+
+### after_STOP_ACTIVITY
+- `"run_end_completion_time_ms"` is set using current time. It is considered as the EOEOR timestamp.
+- `after_STOP_ACTIVITY` hooks are executed:
+  - `trg.RunUnload()` at `-100`
+  - `ccdb.RunStop()`, `dcs.EndOfRun()` at `0`
+  - waiting until `odc.Stop()()` executed at `before_STOP_ACTIVITY` completes at `0`
+  - `bookkeeping.UpdateRunStop()`, `bookkeeping.UpdateEnv()` at `+100`
+
+### after_event
+
+- `after_event` hooks are executed

--- a/docs/handbook/operation_order.md
+++ b/docs/handbook/operation_order.md
@@ -74,5 +74,5 @@ This is the order of actions happening at a healthy end of run.
 - `after_STOP_ACTIVITY` hooks are executed:
   - `trg.RunUnload()` at `-100`
   - `ccdb.RunStop()`, `dcs.EndOfRun()` at `0`
-  - waiting until `odc.Stop()()` executed at `before_STOP_ACTIVITY` completes at `0`
+  - waiting until `odc.Stop()` executed at `before_STOP_ACTIVITY` completes at `0`
   - `bookkeeping.UpdateRunStop()`, `bookkeeping.UpdateEnv()` at `+100`


### PR DESCRIPTION
I think we are at the stage where things have settled down and there is a finite number of changes expected to such a document (namely: removing BKP and Kafka plugins calls, possibly moving CCDB plugin calls). One could even consider filling the hooks automatically, based on the information parsed from `readout-dataflow.yaml`, but I would leave that for later.

The reason for this document is also a request from users to know what are SOSOR, EOSOR, SOEOR, EOEOR timestamps exactly.