### PR TITLE
[core] OCTRL-891 propagate pdp_beam_type and pdp sor override to tasks

### DIFF
--- a/core/environment/transition_startactivity.go
+++ b/core/environment/transition_startactivity.go
@@ -92,6 +92,8 @@ func (t StartActivityTransition) do(env *Environment) (err error) {
 				"run_start_time_ms",
 				"run_end_time_ms", // included to ensure that a cleared SOEOR timestamp is propagated to all tasks during START-STOP-START
 				"lhc_period",
+				"pdp_beam_type",
+				"pdp_override_run_start_time",
 			} {
 				if value, ok := cvs[key]; ok {
 					// we push the above parameters with both camelCase and snake_case identifiers for convenience

--- a/docs/handbook/configuration.md
+++ b/docs/handbook/configuration.md
@@ -101,6 +101,8 @@ In addition to the above, which varies depending on the configuration of the env
  * `runType`
  * `runStartTimeMs`
  * `lhcPeriod`
+ * `pdp_beam_type`
+ * `pdp_override_run_start_time`
 
 FairMQ task implementors should expect that these values are written to the FairMQ properties map right before the `RUN` transition via `SetProperty` calls.
 


### PR DESCRIPTION
pdp_beam_type and pdp_override_run_start_time are propagated to tasks during SOR, so during SYNTHETIC runs they can know the right beam type and start of run correlated with the timing of synthetic data.