### PR TITLE
added logging filters for IL

### DIFF
--- a/cmd/o2-aliecs-core/main.go
+++ b/cmd/o2-aliecs-core/main.go
@@ -87,15 +87,16 @@ func init() {
 		ForceFormatting: true,
 	})
 	log.SetOutput(os.Stdout)
-	ilHook, err := infologger.NewDirectHook("ECS", "core")
-	if err == nil {
-		log.AddHook(ilHook)
-	}
 }
 
 func main() {
 	if err := core.NewConfig(); err != nil {
 		log.Fatal(err)
+	}
+
+	ilHook, err := infologger.NewDirectHook("ECS", "core", nil)
+	if err == nil {
+		log.AddHook(ilHook)
 	}
 
 	if err := core.Run(); err != nil {

--- a/cmd/o2-aliecs-executor/main.go
+++ b/cmd/o2-aliecs-executor/main.go
@@ -37,7 +37,7 @@ import (
 
 func init() {
 	logrus.SetOutput(os.Stdout)
-	ilHook, err := infologger.NewDirectHook("ECS", "executor")
+	ilHook, err := infologger.NewDirectHook("ECS", "executor", logrus.AllLevels)
 	if err == nil {
 		logrus.AddHook(ilHook)
 	}

--- a/cmd/o2-apricot/main.go
+++ b/cmd/o2-apricot/main.go
@@ -35,24 +35,25 @@ import (
 
 func init() {
 	log.SetFormatter(&prefixed.TextFormatter{
-		FullTimestamp:   true,
-		SpacePadding:    20,
-		PrefixPadding:   12,
+		FullTimestamp: true,
+		SpacePadding:  20,
+		PrefixPadding: 12,
 
 		// Needed for colored stdout/stderr in GoLand, IntelliJ, etc.
 		ForceColors:     true,
 		ForceFormatting: true,
 	})
 	log.SetOutput(os.Stdout)
-	ilHook, err := infologger.NewDirectHook("ECS", "apricot")
-	if err == nil {
-		log.AddHook(ilHook)
-	}
 }
 
 func main() {
 	if err := apricot.NewConfig(); err != nil {
 		log.Fatal(err)
+	}
+
+	ilHook, err := infologger.NewDirectHook("ECS", "apricot", nil)
+	if err == nil {
+		log.AddHook(ilHook)
 	}
 
 	if err := apricot.Run(); err != nil {

--- a/core/config.go
+++ b/core/config.go
@@ -124,6 +124,7 @@ func setDefaults() error {
 	viper.SetDefault("taskClassCacheTTL", 7*24*time.Hour)
 	viper.SetDefault("kafkaEndpoints", []string{"localhost:9092"})
 	viper.SetDefault("enableKafka", true)
+	viper.SetDefault("logAllIL", false)
 	return nil
 }
 
@@ -190,6 +191,7 @@ func setFlags() error {
 	pflag.Duration("taskClassCacheTTL", viper.GetDuration("taskClassCacheTTL"), "TTL for task class cache entries")
 	pflag.StringSlice("kafkaEndpoints", viper.GetStringSlice("kafkaEndpoints"), "List of Kafka endpoints to connect to (default: localhost:9092)")
 	pflag.Bool("enableKafka", viper.GetBool("enableKafka"), "Turn on the kafka messaging")
+	pflag.Bool("logAllIL", viper.GetBool("logAllIL"), "Send all the logs into IL, including Debug and Trace messages")
 
 	pflag.Parse()
 	return viper.BindPFlags(pflag.CommandLine)


### PR DESCRIPTION
I had to change how directhook is created, because when it is triggered from `init()` it just uses default values all the time and it isn't settable.  So I moved it from `init()` to `main()` after config is being loaded and parsed.