### PR TITLE
[core] OCTRL-911 do not teardown an environment in DONE

### DIFF
--- a/core/environment/manager.go
+++ b/core/environment/manager.go
@@ -589,6 +589,9 @@ func (envs *Manager) TeardownEnvironment(environmentId uid.ID, force bool) error
 	}
 	defer env.transitionMutex.Unlock()
 
+	if env.CurrentState() == "DONE" {
+		return errors.New("attempting to teardown an environment which is already in DONE, doing nothing")
+	}
 	if env.CurrentState() != "STANDBY" && env.CurrentState() != "DEPLOYED" && !force {
 		return errors.New(fmt.Sprintf("cannot teardown environment in state %s", env.CurrentState()))
 	}
@@ -851,6 +854,7 @@ func (envs *Manager) TeardownEnvironment(environmentId uid.ID, force bool) error
 		return err
 	}
 
+	env.setState("DONE")
 	env.sendEnvironmentEvent(&event.EnvironmentEvent{EnvironmentID: env.Id().String(), Message: "teardown complete", State: "DONE"})
 
 	log.WithField("method", "TeardownEnvironment").


### PR DESCRIPTION
This is a fix to avoid running a second teardown attempt after a successful one. This could have happened if the 2nd teardown request was received while the 1st teardown attempt would be still ongoing. In principle https://github.com/AliceO2Group/Control/pull/600 was already enough to avoid concurrency issues and I could not make the core misbehave with it, but this commit attempts to make the behaviour somewhat more correct.

I hesitated to set the state as DONE if `TeardownEnvironment` returns earlier with an error, since this does not remove given environment from the manager's list of enviroments, thus technically it is still available for more teardown attempts. On another hand, this contradicts the already published kafka events, which advertize the env state as DONE even when it ends with error and the state is not set anyway.