### PR TITLE
[core] OCTRL-912 Cancel calls pending await upon environment destruction

### DIFF
--- a/core/environment/environment.go
+++ b/core/environment/environment.go
@@ -706,6 +706,7 @@ func (env *Environment) handleHooks(workflow workflow.Role, trigger string, weig
 				// respected.
 
 				callErrors = pendingCalls.AwaitAll()
+				delete(env.callsPendingAwait[trigger], weight)
 			}
 		}
 


### PR DESCRIPTION
This addressed the problem of having stuck calls waiting for something to receive from c.await which outlive the parent environments. This may happen if awaited trigger never occurs after it has been started, e.g. if trigger is before_START_ACTIVITY and await is after_START_ACTIVITY, but the environments fails to transition to RUNNING.