### PR TITLE
QC-779  Multiple mesos executor fix

### DIFF
--- a/core/task/scheduler.go
+++ b/core/task/scheduler.go
@@ -1526,7 +1526,7 @@ func makeTaskForMesosResources(
 
 	newTaskId := taskPtr.GetTaskId()
 
-	executor := state.CopyExecutor()
+	executor := state.CopyExecutorInfo()
 	executor.ExecutorID.Value = taskPtr.GetExecutorId()
 	envIdS := envId.String()
 

--- a/core/task/scheduler.go
+++ b/core/task/scheduler.go
@@ -1526,7 +1526,7 @@ func makeTaskForMesosResources(
 
 	newTaskId := taskPtr.GetTaskId()
 
-	executor := state.executor
+	executor := state.CopyExecutor()
 	executor.ExecutorID.Value = taskPtr.GetExecutorId()
 	envIdS := envId.String()
 

--- a/core/task/schedulerstate.go
+++ b/core/task/schedulerstate.go
@@ -36,6 +36,7 @@ import (
 	"github.com/AliceO2Group/Control/common/logger/infologger"
 	"github.com/AliceO2Group/Control/core/controlcommands"
 	"github.com/AliceO2Group/Control/core/task/schedutil"
+	"github.com/gogo/protobuf/proto"
 	"github.com/looplab/fsm"
 	mesos "github.com/mesos/mesos-go/api/v1/lib"
 	"github.com/mesos/mesos-go/api/v1/lib/backoff"
@@ -214,17 +215,6 @@ func (state *schedulerState) Start(ctx context.Context) {
 	}()
 }
 
-func (state *schedulerState) CopyExecutor() *mesos.ExecutorInfo {
-	executorInfoCopy := &mesos.ExecutorInfo{}
-
-	marshaled, err := state.executor.Marshal()
-	if err != nil {
-		return nil
-	}
-
-	err = executorInfoCopy.Unmarshal(marshaled)
-	if err != nil {
-		return nil
-	}
-	return executorInfoCopy
+func (state *schedulerState) CopyExecutorInfo() *mesos.ExecutorInfo {
+	return proto.Clone(state.executor).(*mesos.ExecutorInfo)
 }


### PR DESCRIPTION
sorry for some of the formatting fixes.
There was a race condition which was in method `makeTaskForMesosResources` where we sharing `global` object to write. This should create a deep copy of given object and it seems to fix the problem on staging.