### PR TITLE
moved logs connected to unknown undeployable to Devel

### DIFF
--- a/core/environment/transition_deploy.go
+++ b/core/environment/transition_deploy.go
@@ -245,6 +245,7 @@ func (t DeployTransition) do(env *Environment) (err error) {
 								WithField("partition", env.Id().String()).
 								WithField("timeout", deploymentTimeout).
 								WithField("detector", detector).
+								WithField("level", infologger.IL_Devel).
 								Error("role failed to deploy within timeout")
 							undeployableTaskRoles = append(undeployableTaskRoles, role.GetPath())
 						}
@@ -275,6 +276,7 @@ func (t DeployTransition) do(env *Environment) (err error) {
 							WithField("partition", env.Id().String()).
 							WithField("timeout", deploymentTimeout).
 							WithField("detector", detector).
+							WithField("level", infologger.IL_Devel).
 							Error("role failed to deploy because of timeout")
 						undeployableTaskRoles = append(undeployableTaskRoles, role.GetPath())
 					} else if roleStatus != task.ACTIVE {
@@ -288,6 +290,7 @@ func (t DeployTransition) do(env *Environment) (err error) {
 							WithField("partition", env.Id().String()).
 							WithField("timeout", deploymentTimeout).
 							WithField("detector", detector).
+							WithField("level", infologger.IL_Devel).
 							Error("role failed to deploy because of timeout")
 						inactiveTaskRoles = append(inactiveTaskRoles, role.GetPath())
 					}

--- a/core/task/scheduler.go
+++ b/core/task/scheduler.go
@@ -592,6 +592,7 @@ func (state *schedulerState) resourceOffers(fidStore store.Singleton) events.Han
 						descriptorsUndeployable = append(descriptorsUndeployable, descriptor)
 						descriptorsStillToDeploy = append(descriptorsStillToDeploy[:i], descriptorsStillToDeploy[i+1:]...)
 						log.WithField("partition", envId.String()).
+							WithField("level", infologger.IL_Devel).
 							WithField("descriptor", descriptor.TaskClassName).
 							Errorf("no resource offer for required host %s, deployment will be aborted", requiredMachineId)
 					}


### PR DESCRIPTION
I talked with Vasco and it is possible to release and deploy before HI if we do just log changes. So I went over logs from OCTRL-777 logs and moved these to Devel level so crew will not get overwhelmed when this error (which is covered by retry) is triggered.

For the record: this PR is not meant to be as a whole solution for OCTRL-945, I am still working on more concise logging.