### PR TITLE
[core] do not warn about tasks not in roster when it's expected

### DIFF
--- a/core/task/manager.go
+++ b/core/task/manager.go
@@ -960,9 +960,10 @@ func (m *Manager) GetTask(id string) *Task {
 
 func (m *Manager) updateTaskState(taskId string, state string) {
 	taskPtr := m.roster.getByTaskId(taskId)
-	if taskPtr == nil {
+	if taskPtr == nil && state != "DONE" {
 		log.WithField("taskId", taskId).
 			WithField("state", state).
+			WithField(infologger.Level, infologger.IL_Support).
 			Warn("attempted state update of task not in roster")
 		return
 	}


### PR DESCRIPTION
When scheduling a task kill, we remove it from roster. Thus, when we receive a task state DONE update, there is typically nothing to warn about.

OCTRL-940