### PR TITLE
[core] ODC: Send SOR/EOR timestamps as FMQ properties

### DIFF
--- a/docs/handbook/configuration.md
+++ b/docs/handbook/configuration.md
@@ -455,7 +455,10 @@ In addition to the above, which varies depending on the configuration of the env
  * `pdp_beam_type`
  * `pdp_override_run_start_time`
 
-FairMQ task implementors should expect that these values are written to the FairMQ properties map right before the `RUN` transition via `SetProperty` calls.
+The following values are pushed by AliECS during `STOP_ACTIVITY`:
+ * `run_end_time_ms`
+
+FairMQ task implementors should expect that these values are written to the FairMQ properties map right before the `RUN` and `STOP` transitions via `SetProperty` calls.
 
 ## Resource wants and limits
 


### PR DESCRIPTION
OCTRL-987

This involved extracting `setProperties` as a separate helper to share it between `Start` and `Stop`, and adding it to `Stop`, which was not the case. Contrarily to `Start`, we do not abandon `odc.Stop` in case `setProperties` fails, so we still have an attempt to stop the run.

Tested on staging, it looks like `setProperties` takes 50ms when using 2 EPNs. Looking at the past logs in production, it usually takes no more than 100ms, so I don't think anyone should complain, while this lets us use correct EOR time in QC.