### PR TITLE
[OCTRL-990]: Place kafka events related to the same task in the same partition

### DIFF
--- a/common/event/writer.go
+++ b/common/event/writer.go
@@ -124,7 +124,10 @@ func (w *KafkaWriter) WriteEventWithTimestamp(e interface{}, timestamp time.Time
 				Payload:       &pb.Event_FrameworkEvent{FrameworkEvent: e},
 			}
 		case *pb.Ev_TaskEvent:
-			key = extractAndConvertEnvID(e)
+			key = []byte(e.Taskid)
+			if len(key) == 0 {
+				key = nil
+			}
 			wrappedEvent = &pb.Event{
 				Timestamp:     timestamp.UnixMilli(),
 				TimestampNano: timestamp.UnixNano(),


### PR DESCRIPTION
use task ID for task message instead of environment for `Ev_TaskEvent`.