### PR TITLE
[core] sending enabled links to DCS should require a lower-case var

### DIFF
--- a/apricot/local/service_test.go
+++ b/apricot/local/service_test.go
@@ -410,6 +410,13 @@ var _ = Describe("local service", func() {
 					Expect(err).To(HaveOccurred())
 				})
 			})
+			When("retrieving the detector spelled lower-case for a host", func() {
+				// not supported
+				It("should produce an error", func() {
+					detector, err = svc.GetDetectorForHost("abc")
+					Expect(err).To(HaveOccurred())
+				})
+			})
 		})
 		Describe("getting detectors for hosts", func() {
 			var (
@@ -547,6 +554,13 @@ var _ = Describe("local service", func() {
 			When("retrieving the link IDs for a non-existing detector", func() {
 				It("should produce an error", func() {
 					linkIDs, err = svc.GetAliasedLinkIDsForDetector("NOPE", false)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+			When("retrieving the link IDs for a detector spelled lower-case", func() {
+				// not supported
+				It("should produce an error", func() {
+					linkIDs, err = svc.GetAliasedLinkIDsForDetector("abc", false)
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/core/integration/dcs/dcsutil.go
+++ b/core/integration/dcs/dcsutil.go
@@ -54,7 +54,7 @@ func resolveDefaults(detectorArgMap map[string]string, varStack map[string]strin
 }
 
 func addEnabledLinks(detectorArgMap map[string]string, varStack map[string]string, ecsDetector string, theLog *logrus.Entry) map[string]string {
-	sendDetLinks, ok := varStack[ecsDetector+"_dcs_send_enabled_links"]
+	sendDetLinks, ok := varStack[strings.ToLower(ecsDetector)+"_dcs_send_enabled_links"]
 	if !ok || sendDetLinks != "true" {
 		return detectorArgMap
 	}


### PR DESCRIPTION
It's a small bug, which required the users to use a variable `TOF_dcs_send_enabled_links` instead of `tof_dcs_send_enabled_links` to enable the feature brought in OCTRL-980. Now we require lower-case detector code.

OCTRL-994