### PR TITLE
[core] Remove ddl_list from defaultable values in DCS plugin

### DIFF
--- a/core/integration/dcs/dcsutil.go
+++ b/core/integration/dcs/dcsutil.go
@@ -36,7 +36,7 @@ import (
 
 func resolveDefaults(detectorArgMap map[string]string, varStack map[string]string, ecsDetector string, theLog *logrus.Entry) map[string]string {
 	// Do we have any default expressions for defaultable values?
-	defaultableKeys := []string{"ddl_list"}
+	defaultableKeys := []string{} // at the moment we do not have any defaultable keys
 
 	for _, key := range defaultableKeys {
 		if defaultableValue, ok := detectorArgMap[key]; ok {


### PR DESCRIPTION
In this case, the mechanism was replaced with the outcomes of OCTRL-980, so we do not need ddl_list to be defaultable anymore.

Closes OCTRL-995.