### PR TITLE
[core] fix a recursive mutex locking in task

### DIFF
--- a/core/task/task.go
+++ b/core/task/task.go
@@ -251,6 +251,16 @@ func (t *Task) GetTraits() Traits {
 	return Traits{}
 }
 
+// lock-free version of GetTraits
+func (t *Task) getTraits() Traits {
+	if class := t.GetTaskClass(); class != nil {
+		if t.parent != nil {
+			return t.parent.GetTaskTraits()
+		}
+	}
+	return Traits{}
+}
+
 // Returns a consolidated CommandInfo for this Task, based on Roles tree and
 // Class.
 func (t *Task) BuildTaskCommand(role parentRole) (err error) {
@@ -525,7 +535,7 @@ func (t *Task) SendEvent(ev event.Event) {
 		Hostname:  t.hostname,
 		ClassName: t.className,
 		Path:      t.getParentRolePath(),
-		Traits:    traitsToPbTraits(t.GetTraits()),
+		Traits:    traitsToPbTraits(t.getTraits()),
 	}
 
 	if t.parent == nil {

--- a/core/task/task.go
+++ b/core/task/task.go
@@ -242,20 +242,18 @@ func (t *Task) GetControlMode() controlmode.ControlMode {
 	return controlmode.DIRECT
 }
 
-func (t *Task) GetTraits() Traits {
-	if class := t.GetTaskClass(); class != nil {
-		if t.GetParent() != nil {
-			return t.GetParent().GetTaskTraits()
-		}
+func getTraits(role parentRole) Traits {
+	if role != nil {
+		return role.GetTaskTraits()
 	}
 	return Traits{}
 }
 
-// lock-free version of GetTraits
-func (t *Task) getTraits() Traits {
+func (t *Task) GetTraits() Traits {
 	if class := t.GetTaskClass(); class != nil {
-		if t.parent != nil {
-			return t.parent.GetTaskTraits()
+		parent := t.GetParent()
+		if parent != nil {
+			return getTraits(parent)
 		}
 	}
 	return Traits{}
@@ -535,7 +533,7 @@ func (t *Task) SendEvent(ev event.Event) {
 		Hostname:  t.hostname,
 		ClassName: t.className,
 		Path:      t.getParentRolePath(),
-		Traits:    traitsToPbTraits(t.getTraits()),
+		Traits:    traitsToPbTraits(getTraits(t.parent)),
 	}
 
 	if t.parent == nil {


### PR DESCRIPTION
Fixes a bug reported in OCTRL-999.

The recursive locking happens in the following trace:
```
 5  0x000000000122c829 in github.com/AliceO2Group/Control/core/task.(*Task).GetParent
    at /home/alibuild/sw/BUILD/eb488922a0fabb8512ec137d3a765b22d2941067/Control-Core/go/src/github.com/AliceO2Group/Control/core/task/task.go:741
 6  0x000000000122597c in github.com/AliceO2Group/Control/core/task.(*Task).GetTraits
    at /home/alibuild/sw/BUILD/eb488922a0fabb8512ec137d3a765b22d2941067/Control-Core/go/src/github.com/AliceO2Group/Control/core/task/task.go:248
 7  0x000000000122a217 in github.com/AliceO2Group/Control/core/task.(*Task).SendEvent
    at /home/alibuild/sw/BUILD/eb488922a0fabb8512ec137d3a765b22d2941067/Control-Core/go/src/github.com/AliceO2Group/Control/core/task/task.go:528
    ```