### PR TITLE
[OCTRL-998]: Sending kafka messages in wrong order

### DIFF
--- a/common/event/writer.go
+++ b/common/event/writer.go
@@ -97,91 +97,89 @@ func (w *KafkaWriter) WriteEventWithTimestamp(e interface{}, timestamp time.Time
 		return
 	}
 
-	go func() {
-		var (
-			err          error
-			wrappedEvent *pb.Event
-			key          []byte = nil
-		)
+	var (
+		err          error
+		wrappedEvent *pb.Event
+		key          []byte = nil
+	)
 
-		switch e := e.(type) {
-		case *pb.Ev_MetaEvent_CoreStart:
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_CoreStartEvent{CoreStartEvent: e},
-			}
-		case *pb.Ev_MetaEvent_MesosHeartbeat:
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_MesosHeartbeatEvent{MesosHeartbeatEvent: e},
-			}
-		case *pb.Ev_MetaEvent_FrameworkEvent:
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_FrameworkEvent{FrameworkEvent: e},
-			}
-		case *pb.Ev_TaskEvent:
-			key = []byte(e.Taskid)
-			if len(key) == 0 {
-				key = nil
-			}
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_TaskEvent{TaskEvent: e},
-			}
-		case *pb.Ev_RoleEvent:
-			key = extractAndConvertEnvID(e)
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_RoleEvent{RoleEvent: e},
-			}
-		case *pb.Ev_EnvironmentEvent:
-			key = extractAndConvertEnvID(e)
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_EnvironmentEvent{EnvironmentEvent: e},
-			}
-		case *pb.Ev_CallEvent:
-			key = extractAndConvertEnvID(e)
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_CallEvent{CallEvent: e},
-			}
-		case *pb.Ev_IntegratedServiceEvent:
-			key = extractAndConvertEnvID(e)
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_IntegratedServiceEvent{IntegratedServiceEvent: e},
-			}
-		case *pb.Ev_RunEvent:
-			key = extractAndConvertEnvID(e)
-			wrappedEvent = &pb.Event{
-				Timestamp:     timestamp.UnixMilli(),
-				TimestampNano: timestamp.UnixNano(),
-				Payload:       &pb.Event_RunEvent{RunEvent: e},
-			}
+	switch e := e.(type) {
+	case *pb.Ev_MetaEvent_CoreStart:
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_CoreStartEvent{CoreStartEvent: e},
 		}
+	case *pb.Ev_MetaEvent_MesosHeartbeat:
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_MesosHeartbeatEvent{MesosHeartbeatEvent: e},
+		}
+	case *pb.Ev_MetaEvent_FrameworkEvent:
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_FrameworkEvent{FrameworkEvent: e},
+		}
+	case *pb.Ev_TaskEvent:
+		key = []byte(e.Taskid)
+		if len(key) == 0 {
+			key = nil
+		}
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_TaskEvent{TaskEvent: e},
+		}
+	case *pb.Ev_RoleEvent:
+		key = extractAndConvertEnvID(e)
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_RoleEvent{RoleEvent: e},
+		}
+	case *pb.Ev_EnvironmentEvent:
+		key = extractAndConvertEnvID(e)
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_EnvironmentEvent{EnvironmentEvent: e},
+		}
+	case *pb.Ev_CallEvent:
+		key = extractAndConvertEnvID(e)
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_CallEvent{CallEvent: e},
+		}
+	case *pb.Ev_IntegratedServiceEvent:
+		key = extractAndConvertEnvID(e)
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_IntegratedServiceEvent{IntegratedServiceEvent: e},
+		}
+	case *pb.Ev_RunEvent:
+		key = extractAndConvertEnvID(e)
+		wrappedEvent = &pb.Event{
+			Timestamp:     timestamp.UnixMilli(),
+			TimestampNano: timestamp.UnixNano(),
+			Payload:       &pb.Event_RunEvent{RunEvent: e},
+		}
+	}
 
-		if wrappedEvent == nil {
-			err = fmt.Errorf("unsupported event type")
-		} else {
-			err = w.doWriteEvent(key, wrappedEvent)
-		}
+	if wrappedEvent == nil {
+		err = fmt.Errorf("unsupported event type")
+	} else {
+		err = w.doWriteEvent(key, wrappedEvent)
+	}
 
-		if err != nil {
-			log.WithField("event", e).
-				WithField("level", infologger.IL_Support).
-				Error(err.Error())
-		}
-	}()
+	if err != nil {
+		log.WithField("event", e).
+			WithField("level", infologger.IL_Support).
+			Error(err.Error())
+	}
 }
 
 func (w *KafkaWriter) doWriteEvent(key []byte, e *pb.Event) error {


### PR DESCRIPTION
There was a goroutine in `WriteEventWithTimestamp` which can cause race condition resulting in problems mentioned in ticket OCTRL-998. 

However, there can be performance problems caused by removing this concurrence, as every Kafka write call will wait until the message is send by the writer. This can be prevented by setting writer into async mode. But doing so we won't get any errors that might happen while sending messages. From kafka-go/writer.go Async comment:
```
	// Setting this flag to true causes the WriteMessages method to never block.
	// It also means that errors are ignored since the caller will not receive
	// the returned value. Use this only if you don't care about guarantees of
	// whether the messages were written to kafka.
```