### PR TITLE
update GH runners to use golang v1.22.2

### DIFF
--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-24.04]
-        go: [ '1.21.5' ]
+        go: [ '1.22.2' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
which is the version of golang used in alidist and go.mod