### PR TITLE
[core] put error in the Error field of events

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -314,8 +314,8 @@ func (m *RpcServer) doNewEnvironmentAsync(cxt context.Context, userVars map[stri
 		the.EventWriterWithTopic(topic.Environment).WriteEvent(&evpb.Ev_EnvironmentEvent{
 			EnvironmentId:   id.String(),
 			State:           "ERROR",
-			Error:           "cannot create new environment",
-			Message:         err.Error(),
+			Error:           err.Error(),
+			Message:         "cannot create new environment", // GUI listens for this concrete string
 			LastRequestUser: requestUser,
 			WorkflowTemplateInfo: &evpb.WorkflowTemplateInfo{
 				Public: public,
@@ -330,8 +330,8 @@ func (m *RpcServer) doNewEnvironmentAsync(cxt context.Context, userVars map[stri
 		the.EventWriterWithTopic(topic.Environment).WriteEvent(&evpb.Ev_EnvironmentEvent{
 			EnvironmentId:   id.String(),
 			State:           "ERROR",
-			Error:           "cannot get newly created environment",
-			Message:         err.Error(),
+			Error:           err.Error(),
+			Message:         "cannot get newly created environment", // GUI listens for this concrete string
 			LastRequestUser: requestUser,
 			WorkflowTemplateInfo: &evpb.WorkflowTemplateInfo{
 				Public: public,


### PR DESCRIPTION
This swaps Error and Message in two kafka events which deviated from the general convention, where Message contains a general, hard-coded string explaining a moment/step that an environment was at, while Error contains the specific error. It was agreed with George and this allow COG to look for "cannot create new environment" and "cannot get newly created environment" message to report the global error of an environment creation failure.