### PR TITLE
Kafka adjustments

### DIFF
--- a/common/event/writer_test.go
+++ b/common/event/writer_test.go
@@ -27,7 +27,6 @@ package event
 import (
 	"sync"
 
-	"github.com/AliceO2Group/Control/common/monitoring"
 	pb "github.com/AliceO2Group/Control/common/protos"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,7 +46,7 @@ var _ = Describe("Writer", func() {
 			writer.runningWorkers = sync.WaitGroup{}
 			writer.batchingLoopDoneCh = make(chan struct{}, 1)
 
-			writer.writeFunction = func(messages []kafka.Message, _ *monitoring.Metric) {
+			writer.writeFunction = func(messages []kafka.Message) {
 				Expect(len(messages)).To(Equal(1))
 				event := &pb.Event{}
 				proto.Unmarshal(messages[0].Value, event)


### PR DESCRIPTION
this is follow up on OCTRL-1003 with changes to kafka which I used to test metrics on STG and openstack. Just small tuneup of kafka-go producer, so it does not take 1s to send batch of messages which is incomplete (not 100 messages).

This branch is based on OCTRL-1003 (to distinguish metrics changes and kafka changes) so that one should be merged first to see real changes just in writer.go and writer_test.go