### PR TITLE
[core] fix malformatted fill_info_fill_number passed to controlled tasks

### DIFF
--- a/core/integration/bookkeeping/plugin.go
+++ b/core/integration/bookkeeping/plugin.go
@@ -1440,7 +1440,7 @@ func (p *Plugin) CallStack(data interface{}) (stack map[string]interface{}) {
 				Errorf("could not access the parent role when trying to propagate the LHC fill info")
 			return
 		}
-		parentRole.SetGlobalRuntimeVar("fill_info_fill_number", string(lhcInfo.FillNumber))
+		parentRole.SetGlobalRuntimeVar("fill_info_fill_number", strconv.FormatInt(int64(lhcInfo.FillNumber), 10))
 		parentRole.SetGlobalRuntimeVar("fill_info_filling_scheme", lhcInfo.FillingSchemeName)
 		parentRole.SetGlobalRuntimeVar("fill_info_beam_type", lhcInfo.BeamType)
 		if lhcInfo.StableBeamsStart != nil {


### PR DESCRIPTION
int32 to string() conversion takes the bytes literally, one should use strconv library instead. Fixes OCTRL-1014.