### PR TITLE
[OCTRL-1016]:  Missing runNumber in KafkaEvent on topic aliecs.run

### DIFF
--- a/core/environment/transition_startactivity.go
+++ b/core/environment/transition_startactivity.go
@@ -81,7 +81,6 @@ func (t StartActivityTransition) do(env *Environment) (err error) {
 	// Get a handle to the consolidated var stack of the root role of the env's workflow
 	if wf := env.Workflow(); wf != nil {
 		if cvs, cvsErr := wf.ConsolidatedVarStack(); cvsErr == nil {
-
 			// If bookkeeping is enabled and has fetched the LHC fill info, we can acquire it here
 			for _, key := range []string{
 				"fill_info_fill_number",
@@ -118,7 +117,6 @@ func (t StartActivityTransition) do(env *Environment) (err error) {
 	incomingEv := <-env.stateChangedCh
 	// If some tasks failed to transition
 	if tasksStateErrors := incomingEv.GetTasksStateChangedError(); tasksStateErrors != nil {
-		env.currentRunNumber = 0
 		return tasksStateErrors
 	}
 


### PR DESCRIPTION
I moved resetting of currentRunNumber from `StartActivityTransition` object if some tasks fail to start to `GO_ERROR` transition after message of EOEOR is send.

@knopers8 Do you think that this can break something? Or do you propose something else?