### PR TITLE
No need to force ERROR when GO_ERROR succeeded

### DIFF
--- a/core/environment/manager.go
+++ b/core/environment/manager.go
@@ -997,8 +997,8 @@ func (envs *Manager) handleIntegratedServiceEvent(evt event.IntegratedServiceEve
 									WithField("partition", envId.String()).
 									WithError(err).
 									Error("environment GO_ERROR transition failed after ODC_PARTITION_STATE_CHANGE ERROR event")
+								env.setState("ERROR")
 							}
-							env.setState("ERROR")
 						}
 					}()
 				}


### PR DESCRIPTION
Probably due to a mostly harmless mistake, we would force an environment into ERROR state even when not needed, after a successful GO_ERROR. If very unlucky, this could cause some conflicts with following transitions towards environment destruction.

This affects only GO_ERROR due to ODC going to ERROR, other cases are fine.

I did not see this bug cause any troubles, I just accidentally stumbled upon it.