### PR TITLE
Add a message for the event reporting successful environment creation

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -352,6 +352,7 @@ func (m *RpcServer) doNewEnvironmentAsync(cxt context.Context, userVars map[stri
 		State:                newEnv.CurrentState(),
 		LastRequestUser:      requestUser,
 		WorkflowTemplateInfo: newEnv.GetWorkflowInfo(),
+		Message:              "created new environment",
 	})
 	return
 }


### PR DESCRIPTION
This becomes consistent with two other events in this function, which report failure to create an environment.