### PR TITLE
Fix race condition in tests

### DIFF
--- a/common/monitoring/monitoring.go
+++ b/common/monitoring/monitoring.go
@@ -155,26 +155,26 @@ func handleFunc(endpointName string) {
 //
 // If we attempt send more messages than the size of the buffer, these overflowing messages will be ignored and warning will be logged.
 func Run(port uint16, endpointName string) error {
-	srv := &http.Server{Addr: fmt.Sprintf(":%d", port)}
+	localServer := &http.Server{Addr: fmt.Sprintf(":%d", port)}
 	// only one Run should initialize and serve
-	if !server.CompareAndSwap(nil, srv) {
+	if !server.CompareAndSwap(nil, localServer) {
 		return nil
 	}
 	initChannels()
 	go eventLoop()
 	handleFunc(endpointName)
 	// block until Shutdown is called
-	return srv.ListenAndServe()
+	return localServer.ListenAndServe()
 }
 
 func Stop() {
-	srv := server.Swap(nil)
-	if srv == nil {
+	localServer := server.Swap(nil)
+	if localServer == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	srv.Shutdown(ctx)
+	localServer.Shutdown(ctx)
 	endChannel <- struct{}{}
 	<-endChannel
 }

--- a/common/monitoring/monitoring_test.go
+++ b/common/monitoring/monitoring_test.go
@@ -81,20 +81,12 @@ func TestStartMultipleStop(t *testing.T) {
 	Stop()
 }
 
-func cleaningUpAfterTest() {
-	Stop()
-}
-
-func initTest() {
-	go Run(12345, "notimportant")
-}
-
 // decorator function that properly inits and cleans after higher level test of Monitoring package
 func testFunction(t *testing.T, testToRun func(*testing.T)) {
-	initTest()
+	go Run(12345, "notimportant")
 	isRunningWithTimeout(t, time.Second)
 	testToRun(t)
-	cleaningUpAfterTest()
+	Stop()
 }
 
 func TestSendingSingleMetric(t *testing.T) {


### PR DESCRIPTION
This patch fixes the `panic: runtime error: invalid memory address or nil pointer dereference` error triggering in tests. It was caused by the racecondition between `Run()` and `Stop()`. `Run` is blocking so it has to be called in goroutine (that is on purpose so we can handle errors in core) so sometimes `Stop()` is called to quickly before `Run` is done, so you could call `ListenAndServe` on an empty object. 
Usage of atomic pointer is not strictly necessary for the fix of mentioned problem. But it assures that no goroutine will be stuck if we change global server too quickly. Usage of the atomic pointer doesn't cause any performance penalty as it just holds the global server and nothing more.

This bug couldn't influence production as we didn't call `Run()` and immediately `Stop()`.