### PR TITLE
OCTRL-678 Pass the error message to BKP in case of GO_ERROR

### DIFF
--- a/core/environment/environment.go
+++ b/core/environment/environment.go
@@ -1176,6 +1176,15 @@ func (env *Environment) QueryRoles(pathSpec string) (rs []workflow.Role) {
 	return
 }
 
+func (env *Environment) GetId() uid.ID {
+	if env == nil {
+		return ""
+	}
+	env.Mu.RLock()
+	defer env.Mu.RUnlock()
+	return env.id
+}
+
 func (env *Environment) GetPath() string {
 	return ""
 }
@@ -1222,7 +1231,12 @@ func (env *Environment) subscribeToWfState(taskman *task.Manager) {
 								log.WithField("partition", env.id).
 									WithField("level", infologger.IL_Ops).
 									Error("one of the critical tasks went into ERROR state, transitioning the environment into ERROR")
+
+								the.EventWriterWithTopic(topic.Environment).WriteEvent(
+									NewEnvGoErrorEvent(env, newCriticalTasksErrorMessage(env)),
+								)
 								err := env.TryTransition(NewGoErrorTransition(taskman))
+
 								if err != nil {
 									if env.Sm.Current() == "ERROR" {
 										log.WithField("partition", env.id).
@@ -1471,6 +1485,11 @@ func (env *Environment) scheduleAutoStopTransition() (scheduled bool, expected t
 						log.WithField("partition", env.id).
 							WithField("run", env.currentRunNumber).
 							Errorf("Scheduled auto stop transition failed: %s, Transitioning into ERROR", err.Error())
+
+						the.EventWriterWithTopic(topic.Environment).WriteEvent(
+							NewEnvGoErrorEvent(env, fmt.Sprintf("scheduled auto stop transition failed: %s", err.Error())),
+						)
+
 						err = env.TryTransition(NewGoErrorTransition(ManagerInstance().taskman))
 						if err != nil {
 							log.WithField("partition", env.id).

--- a/core/environment/manager.go
+++ b/core/environment/manager.go
@@ -488,6 +488,9 @@ func (envs *Manager) CreateEnvironment(workflowPath string, userVars map[string]
 						WithError(err).
 						Warnf("auto-transitioning environment failed %s, cleanup in progress", op)
 
+					the.EventWriterWithTopic(topic.Environment).WriteEvent(
+						NewEnvGoErrorEvent(env, fmt.Sprintf("%s failed: %v", op, err)),
+					)
 					err := env.TryTransition(NewGoErrorTransition(
 						envs.taskman),
 					)
@@ -592,6 +595,9 @@ func (envs *Manager) CreateEnvironment(workflowPath string, userVars map[string]
 		WithField("level", infologger.IL_Devel).
 		Error("environment deployment and configuration error, cleanup in progress")
 
+	the.EventWriterWithTopic(topic.Environment).WriteEvent(
+		NewEnvGoErrorEvent(env, fmt.Sprintf("deployment or configuration failed: %v", err)),
+	)
 	errTxErr := env.TryTransition(NewGoErrorTransition(
 		envs.taskman),
 	)
@@ -1052,6 +1058,9 @@ func (envs *Manager) handleIntegratedServiceEvent(evt event.IntegratedServiceEve
 						}
 
 						if env.CurrentState() != "ERROR" {
+							the.EventWriterWithTopic(topic.Environment).WriteEvent(
+								NewEnvGoErrorEvent(env, "ODC partition went to ERROR during RUNNING"),
+							)
 							err = env.TryTransition(NewGoErrorTransition(envs.taskman))
 							if err != nil {
 								log.WithPrefix("scheduler").
@@ -1376,6 +1385,9 @@ func (envs *Manager) CreateAutoEnvironment(workflowPath string, userVars map[str
 			WithError(err).
 			Warnf("auto-transitioning environment failed %s, cleanup in progress", op)
 
+		the.EventWriterWithTopic(topic.Environment).WriteEvent(
+			NewEnvGoErrorEvent(env, fmt.Sprintf("%s failed: %v", op, err)),
+		)
 		err := env.TryTransition(NewGoErrorTransition(
 			envs.taskman),
 		)

--- a/core/server.go
+++ b/core/server.go
@@ -28,6 +28,7 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 	"runtime"
 	"sort"
@@ -646,6 +647,9 @@ func (m *RpcServer) ControlEnvironment(cxt context.Context, req *pb.ControlEnvir
 			WithField("level", infologger.IL_Ops).
 			WithError(err).
 			Errorf("transition '%s' failed, transitioning into ERROR.", req.GetType().String())
+		the.EventWriterWithTopic(topic.Environment).WriteEvent(
+			environment.NewEnvGoErrorEvent(env, fmt.Sprintf("transition %s failed: %v", req.GetType().String(), err)),
+		)
 		err = env.TryTransition(environment.NewGoErrorTransition(m.state.taskman))
 		if err != nil {
 			log.WithField("partition", env.Id()).Warnf("could not complete requested GO_ERROR transition, forcing move to ERROR: %s", err.Error())

--- a/core/task/task.go
+++ b/core/task/task.go
@@ -151,6 +151,13 @@ func (t *Task) SetSafeToStop(done bool) {
 	t.safeToStop = done
 }
 
+func (t *Task) GetState() sm.State {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.state
+}
+
 func (t *Task) GetParentRole() interface{} {
 	t.mu.RLock()
 	defer t.mu.RUnlock()


### PR DESCRIPTION
An error message is now propagated to kafka events just before scheduling a GO_ERROR transition.