### PR TITLE
Fixes for boost 1.90

### DIFF
--- a/occ/occlib/OccServer.cxx
+++ b/occ/occlib/OccServer.cxx
@@ -23,6 +23,9 @@
  * Intergovernmental Organization or submit itself to any jurisdiction.
  */
 
+#define BOOST_NO_CXX20_HDR_CONCEPTS // TODO: David Rohr: Fix the
+                                    // boost::lockfree::queue, must
+                                    // not use trivial constructor!!!
 
 #include "OccServer.h"
 
@@ -65,7 +68,7 @@ grpc::Status OccServer::EventStream(grpc::ServerContext* context,
                                     const occ_pb::EventStreamRequest* request,
                                     grpc::ServerWriter<occ_pb::EventStreamReply>* writer)
 {
-    boost::uuids::basic_random_generator<boost::mt19937> gen;
+    boost::uuids::basic_random_generator<std::mt19937> gen;
     std::string id = boost::uuids::to_string(gen());
 
     boost::lockfree::queue<occ_pb::DeviceEvent*> eventQueue;
@@ -100,7 +103,7 @@ grpc::Status OccServer::StateStream(grpc::ServerContext* context,
     (void) context;
     (void) request;
 
-    boost::uuids::basic_random_generator<boost::mt19937> gen;
+    boost::uuids::basic_random_generator<std::mt19937> gen;
     std::string id = boost::uuids::to_string(gen());
 
     boost::lockfree::queue<t_State> stateQueue;

--- a/occ/plugin/OccFMQCommon.cxx
+++ b/occ/plugin/OccFMQCommon.cxx
@@ -28,6 +28,8 @@
 #include "util/Defer.h"
 
 #include <boost/algorithm/string.hpp>
+#include <boost/uuid/entropy_error.hpp>
+#include <boost/uuid/uuid_generators.hpp>
 #include <iomanip>
 
 std::string generateSubscriptionId(const std::string& prefix)


### PR DESCRIPTION
This makes it compile with boost 1.90 for now. But we should modernize the boost usage in Control! Eventually, some of the deprecated boost features like the boost random number generators will be removed, we should switch to std::...
And the boost lockfree queue is used incorrectly, it must not be called with a trivial constructor, if no compile-time capacity is provided.