### PR TITLE
Hook control mode was changed to direct in task

### DIFF
--- a/core/task/taskclass/class.go
+++ b/core/task/taskclass/class.go
@@ -123,7 +123,6 @@ func (c *Class) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
 		}
 	}
 	return
-
 }
 
 func (c *Class) MarshalYAML() (interface{}, error) {
@@ -153,14 +152,7 @@ func (c *Class) MarshalYAML() (interface{}, error) {
 		Constraints: c.Constraints,
 		Command:     c.Command,
 	}
-
-	if c.Control.Mode == controlmode.FAIRMQ {
-		aux.Control.Mode = "fairmq"
-	} else if c.Control.Mode == controlmode.BASIC {
-		aux.Control.Mode = "basic"
-	} else {
-		aux.Control.Mode = "direct"
-	}
+	aux.Control.Mode = c.Control.Mode.String()
 
 	return aux, nil
 }


### PR DESCRIPTION
During my kubernetes work, I found this weird forking of control mode in task.go which silently move hook to direct control task. This seems weird especially when we have dedicated HookTask ([see](https://github.com/AliceO2Group/Control/blob/master/executor/executable/task.go#L151-L164)). I cannot say whether this was done deliberately or whether it is a bug, but it feels like a bug.