### PR TITLE
Update go version used in CI

### DIFF
--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-24.04]
-        go: [ '1.24.2' ]
+        go: [ '1.25.0' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
It was updated in go.mod, but I forgot to update it here.