### PR TITLE
alice-tasks namespace in yaml manifests

### DIFF
--- a/control-operator/ecs-manifests/environment/test_env.yaml
+++ b/control-operator/ecs-manifests/environment/test_env.yaml
@@ -2,6 +2,7 @@ apiVersion: aliecs.alice.cern/v1alpha1
 kind: Environment
 metadata:
   name: 31jdwll4xl6
+  namespace: alice-tasks
 
 taskTemplates:
   tasks:

--- a/control-operator/ecs-manifests/kubernetes-manifests/readout-test.yaml
+++ b/control-operator/ecs-manifests/kubernetes-manifests/readout-test.yaml
@@ -2,6 +2,7 @@ apiVersion: aliecs.alice.cern/v1alpha1
 kind: Task
 metadata:
   name: readout
+  namespace: alice-tasks
 spec:
   arguments:
     chans.readout.0.address: ipc://@o2ipc-d7ef3du8ndmd7n8j7l2g
@@ -99,6 +100,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: readout-config
+  namespace: alice-tasks
 data:
   readout-cfg.ini: |
     # Example configuration file for o2-readout-exe

--- a/control-operator/ecs-manifests/kubernetes-manifests/stfbuilder-senderoutput-test.yaml
+++ b/control-operator/ecs-manifests/kubernetes-manifests/stfbuilder-senderoutput-test.yaml
@@ -2,6 +2,7 @@ apiVersion: aliecs.alice.cern/v1alpha1
 kind: Task
 metadata:
   name: stfbuilder-senderoutput
+  namespace: alice-tasks
 spec:
   arguments:
     chans.buildertosender.0.address: ipc://@o2ipc-d7ef3du8ndmd7n8j7l30

--- a/control-operator/ecs-manifests/kubernetes-manifests/stfsender-test.yaml
+++ b/control-operator/ecs-manifests/kubernetes-manifests/stfsender-test.yaml
@@ -2,6 +2,7 @@ apiVersion: aliecs.alice.cern/v1alpha1
 kind: Task
 metadata:
   name: stfsender
+  namespace: alice-tasks
 spec:
   arguments:
     chans.buildertosender.0.address: ipc://@o2ipc-d7ef3du8ndmd7n8j7l30

--- a/control-operator/ecs-manifests/task-templates/readout-tasktemplate.yaml
+++ b/control-operator/ecs-manifests/task-templates/readout-tasktemplate.yaml
@@ -2,6 +2,7 @@ apiVersion: aliecs.alice.cern/v1alpha1
 kind: TaskTemplate
 metadata:
   name: readout
+  namespace: alice-tasks
 spec:
   envVars:
     - O2_DETECTOR

--- a/control-operator/ecs-manifests/task-templates/stfbuilder-senderoutput-tasktemplate.yaml
+++ b/control-operator/ecs-manifests/task-templates/stfbuilder-senderoutput-tasktemplate.yaml
@@ -2,6 +2,7 @@ apiVersion: aliecs.alice.cern/v1alpha1
 kind: TaskTemplate
 metadata:
   name: stfbuilder-senderoutput
+  namespace: alice-tasks
 spec:
   envVars:
     - O2_DETECTOR

--- a/control-operator/ecs-manifests/task-templates/stfsender-tasktemplate.yaml
+++ b/control-operator/ecs-manifests/task-templates/stfsender-tasktemplate.yaml
@@ -2,6 +2,7 @@ apiVersion: aliecs.alice.cern/v1alpha1
 kind: TaskTemplate
 metadata:
   name: stfsender
+  namespace: alice-tasks
 spec:
   envVars:
     - O2_DETECTOR


### PR DESCRIPTION
I introduced this change so we can easily filter through the all tasks/environments on cluster. It is used for example in OpenSearch log display.