### PR TITLE
nodeName set in test manifests

### DIFF
--- a/control-operator/ecs-manifests/kubernetes-manifests/readout-test.yaml
+++ b/control-operator/ecs-manifests/kubernetes-manifests/readout-test.yaml
@@ -3,6 +3,7 @@ kind: Task
 metadata:
   name: readout
 spec:
+  nodeName: mtichak-ost.cern.ch
   arguments:
     chans.readout.0.address: ipc://@o2ipc-d7ef3du8ndmd7n8j7l2g
     chans.readout.0.autoBind: "0"

--- a/control-operator/ecs-manifests/kubernetes-manifests/stfbuilder-senderoutput-test.yaml
+++ b/control-operator/ecs-manifests/kubernetes-manifests/stfbuilder-senderoutput-test.yaml
@@ -3,6 +3,7 @@ kind: Task
 metadata:
   name: stfbuilder-senderoutput
 spec:
+  nodeName: mtichak-ost.cern.ch
   arguments:
     chans.buildertosender.0.address: ipc://@o2ipc-d7ef3du8ndmd7n8j7l30
     chans.buildertosender.0.autoBind: "0"

--- a/control-operator/ecs-manifests/kubernetes-manifests/stfsender-test.yaml
+++ b/control-operator/ecs-manifests/kubernetes-manifests/stfsender-test.yaml
@@ -3,6 +3,7 @@ kind: Task
 metadata:
   name: stfsender
 spec:
+  nodeName: mtichak-ost.cern.ch
   arguments:
     chans.buildertosender.0.address: ipc://@o2ipc-d7ef3du8ndmd7n8j7l30
     chans.buildertosender.0.method: connect


### PR DESCRIPTION
this behavior changed few commits back, but I forgot to add properly working *-test.yaml manifests.