### PR TITLE
[OCTRL-1091] OCC_CONTROL_PORT removal from TaskTemplate CRDs

### DIFF
--- a/control-operator/ecs-manifests/task-templates/readout-tasktemplate.yaml
+++ b/control-operator/ecs-manifests/task-templates/readout-tasktemplate.yaml
@@ -16,6 +16,9 @@ spec:
       - name: readout
         image: gitlab-registry.cern.ch/aliceo2group/dockerfiles/alma9-flp-node/readout:1
         command: ["/opt/o2/bin/o2-readout-exe"]
+        env:
+          - name: OCC_CONTROL_PORT
+            value: "47101"
         securityContext:
           privileged: true
         volumeMounts:

--- a/control-operator/ecs-manifests/task-templates/stfbuilder-senderoutput-tasktemplate.yaml
+++ b/control-operator/ecs-manifests/task-templates/stfbuilder-senderoutput-tasktemplate.yaml
@@ -19,6 +19,9 @@ spec:
       - name: stfbuilder
         image: gitlab-registry.cern.ch/aliceo2group/dockerfiles/alma9-flp-node/dd:1
         command: [/opt/o2/bin/StfBuilder]
+        env:
+          - name: OCC_CONTROL_PORT
+            value: "47102"
         securityContext:
           privileged: true
         volumeMounts:

--- a/control-operator/ecs-manifests/task-templates/stfsender-tasktemplate.yaml
+++ b/control-operator/ecs-manifests/task-templates/stfsender-tasktemplate.yaml
@@ -26,6 +26,9 @@ spec:
       - name: stfsender
         image: gitlab-registry.cern.ch/aliceo2group/dockerfiles/alma9-flp-node/dd:1
         command: ["numactl"]
+        env:
+          - name: OCC_CONTROL_PORT
+            value: "47103"
         securityContext:
           privileged: true
         volumeMounts:

--- a/control-operator/internal/controller/environment_controller.go
+++ b/control-operator/internal/controller/environment_controller.go
@@ -83,27 +83,11 @@ func (r *EnvironmentReconciler) runTasksFromReferenceOnNode(ctx context.Context,
 		task.Spec.Pod = *template.Spec.Pod.DeepCopy()
 		task.Spec.Control = *template.Spec.Control.DeepCopy()
 
-		// TODO: regarding error handling. Is it correct to stop while handling one task? this will fail the whole deployment,
-		// 		 which might not be desirable outcome especially for non-critical tasks
-		if foundIdx := slices.IndexFunc(taskReference.Env, func(envVar v1.EnvVar) bool { return envVar.Name == "OCC_CONTROL_PORT" }); foundIdx == -1 {
-			log.Error(fmt.Errorf("didn't find OCC_CONTROL_PORT in env"), "failed to fill in env vars from template")
-			return &reconcile.Result{}, nil
-		} else {
-			port, err := strconv.Atoi(taskReference.Env[foundIdx].Value)
-			if err != nil {
-				log.Error(fmt.Errorf("found OCC_CONTROL_PORT isn't convertible to number "), "failed to fill in env vars from template")
-				return &reconcile.Result{}, nil
-			}
-			task.Spec.Control.Port = port
-		}
-
 		if task.Spec.Arguments == nil {
 			task.Spec.Arguments = make(map[string]string)
 		}
 
-		// TODO: check for containers!
-		task.Spec.Pod.Containers[0].Env = append(task.Spec.Pod.Containers[0].Env, taskReference.Env...)
-		task.Spec.Pod.Containers[0].Args = append(task.Spec.Pod.Containers[0].Args, taskReference.ArgsCLI...)
+		handleEnvVars(task, taskReference)
 		maps.Copy(task.Spec.Arguments, taskReference.ArgsTransition)
 
 		task.Spec.Pod.NodeName = nodename
@@ -125,6 +109,34 @@ func (r *EnvironmentReconciler) runTasksFromReferenceOnNode(ctx context.Context,
 		}
 	}
 	return nil, nil
+}
+
+func handleEnvVars(task *aliecsv1alpha1.Task, taskReference aliecsv1alpha1.TaskReference) {
+	// TODO: check for existence of containers
+	// TODO: adapt for Pods with multiple containers
+	// reference to existing Env Vars to overwrite them if found in taskReference
+	existing := make(map[string]int, len(task.Spec.Pod.Containers[0].Env))
+	for i, e := range task.Spec.Pod.Containers[0].Env {
+		existing[e.Name] = i
+	}
+	for _, e := range taskReference.Env {
+		if i, ok := existing[e.Name]; ok {
+			task.Spec.Pod.Containers[0].Env[i] = e
+		} else {
+			task.Spec.Pod.Containers[0].Env = append(task.Spec.Pod.Containers[0].Env, e)
+		}
+	}
+	task.Spec.Pod.Containers[0].Args = append(task.Spec.Pod.Containers[0].Args, taskReference.ArgsCLI...)
+
+	// TODO: should the OCC_CONTROL_PORT handled in task_controller.go and set only Ports and types in this controller?
+	for _, envVar := range task.Spec.Pod.Containers[0].Env {
+		if envVar.Name == "OCC_CONTROL_PORT" {
+			if port, err := strconv.Atoi(envVar.Value); err == nil {
+				task.Spec.Control.Port = port
+			}
+			break
+		}
+	}
 }
 
 func (r *EnvironmentReconciler) runTaskFromDefinitionOnNode(ctx context.Context, taskDefs []aliecsv1alpha1.TaskDefinition,


### PR DESCRIPTION
Core provides `OCC_CONTROL_PORT` variable only for Mesos tasks, where it is generated by Mesos. However, TaskTemplate CRD needed this variable to be filled in by during usage by TaskReference. So I moved the `OCC_CONTROL_PORT` setup directly into the TaskTemplate CRD to not rely on core at all. This approach is ok, because when we have non-host networking for containers we can basically setup any port because those would not clash thanks to k8s internal networking. But for now we manually setup unique ports in each TaskTemplate because we use host network.